### PR TITLE
update default OpenAI model to `gpt-4o-mini`

### DIFF
--- a/SimWorks/services/openai_chat.py
+++ b/SimWorks/services/openai_chat.py
@@ -103,13 +103,21 @@ def get_initial_response(
         simulation.prompt_id = get_default_prompt()
         simulation.save()
 
-    prompt = simulation.prompt.content.strip()
-    prompt += f"\n\nYour name is {simulation.sim_patient_full_name}. Stay in character as {simulation.sim_patient_full_name} and respond accordingly."
+    model_instruction = simulation.prompt.content.strip()
+    model_instruction += f"\n\nYour name is {simulation.sim_patient_full_name}. Stay in character as {simulation.sim_patient_full_name} and respond accordingly."
 
     response = client.responses.create(
         model=model,
-        instructions=prompt,
-        input='Begin Simulation.',
+        input=[
+            {
+                "role": "developer",
+                "content": model_instruction,
+            },
+            {
+                "role": "user",
+                "content": "Begin simulation",
+            },
+        ],
     )
 
     logger.debug(f"Generated initial scenario message for Simulation {simulation.id}")


### PR DESCRIPTION
This PR updates the get_initial_response function in openai_chat.py to use OpenAI’s structured message input format (i.e., [{role: ..., content: ...}]) instead of the previous instructions + input approach.

	•	Renames prompt to model_instruction to reflect its use in the message payload.

Why
	•	Aligns with OpenAI’s preferred API structure for multi-turn conversations using input=[...] with role-tagged messages.
	•	Provides better flexibility and clarity when crafting simulation context and instructions.
	•	Future-proofs the codebase for extended multi-turn interactions or system conditioning.

Notes
	•	No behavior changes are expected from this refactor — the AI should still return initial scenario responses with metadata and simulated patient dialogue.
	•	This version is better aligned with how follow-up messages are likely to be structured in future updates.