### PR TITLE
Fix chat-form failing to lock on simulation end.

### DIFF
--- a/SimWorks/ChatLab/templates/ChatLab/chat.html
+++ b/SimWorks/ChatLab/templates/ChatLab/chat.html
@@ -36,12 +36,15 @@
   <!-- Typing indicator -->
   {% include "ChatLab/partials/typing_indicator.html" %}
 
+{% comment %}
   <!-- Input form -->
 {% if simulation_locked %}
     <p class="text-muted">Simulation complete. Chat is now read-only.</p>
 {% else %}
     {% include 'ChatLab/partials/input_form.html' %}
 {% endif %}
+{% endcomment %}
+{% include 'ChatLab/partials/input_form.html' %}
 </section>
 
 <audio id="send-sound" preload="auto">

--- a/SimWorks/ChatLab/templates/ChatLab/partials/input_form.html
+++ b/SimWorks/ChatLab/templates/ChatLab/partials/input_form.html
@@ -1,6 +1,9 @@
 {% load static %}
 
-<form id="chat-form" @submit.prevent="sendMessage">
+<form id="chat-form"
+    @submit.prevent="sendMessage"
+    x-data="{ isLocked: {{ simulation.is_ended|yesno:'true,false' }} }"
+>
   <button type="button" id="emoji-button" title="Emoji" class="emoji-button hide-small">
         <span class="iconify chat-icon" data-icon="fa6-regular:face-smile" data-inline="false"></span>
   </button>
@@ -8,11 +11,17 @@
     x-model="messageText"
     id="chat-message-input"
     type="text"
-    placeholder="Message..."
+    :disabled="isLocked"
+    :placeholder="isLocked ? 'Simulation locked.' : 'Message'"
     @input="notifyTyping"
     autofocus
   >
-    <button type="submit">
-      <span class="iconify chat-icon mr-4 color-accent-blue" data-icon="bi:arrow-up-circle-fill" data-inline="false"></span>
+    <button type="submit" :disabled="isLocked">
+      <span
+          class="iconify chat-icon mr-4"
+          :class="{ 'color-accent-blue': !isLocked }"
+          data-icon="bi:arrow-up-circle-fill"
+          data-inline="false"
+      ></span>
     </button>
 </form>

--- a/SimWorks/ChatLab/views.py
+++ b/SimWorks/ChatLab/views.py
@@ -119,16 +119,16 @@ def run_simulation(request, simulation_id):
             "You do not have permission to view this simulation."
         )
 
-    if simulation.is_complete:
-        simulated_locked = True
-    else:
-        simulated_locked = False
+    # if simulation.is_complete:
+    #     simulation_locked = True
+    # else:
+    #     simulation_locked = False
 
     context = {
         "simulation": simulation,
         "metadata": metadata,
         "sim_start_unix": int(simulation.start.timestamp() * 1000),
-        "simulated_locked": simulated_locked,
+        "simulation_locked": simulation.is_complete,
     }
 
     return render(request, "ChatLab/simulation.html", context)
@@ -190,4 +190,5 @@ def end_simulation(request, simulation_id):
     if not simulation.end:
         simulation.end = now()
         simulation.save()
+
     return redirect("ChatLab:run_simulation", simulation_id=simulation.id)


### PR DESCRIPTION
Previously, users would be able to continue sending messages after a simulation had ended due to a typo (`simulate`_locked` vs `simulation_locked`). This workflow was simplied to use `simulation.is_ended`, and the UI improved to visually and systematically lock the chat-form.