### PR TITLE
improve tool-header UI; add touch and borders

### DIFF
--- a/SimWorks/chatlab/static/chatlab/css/simulation.css
+++ b/SimWorks/chatlab/static/chatlab/css/simulation.css
@@ -72,7 +72,7 @@
 .sim-sidebar-wrapper {
     width: 100%;
 }
-.metadata-header {
+.tool-header {
     display: flex;
     justify-content: space-between;
     gap: 0.5rem;

--- a/SimWorks/chatlab/static/chatlab/css/simulation.css
+++ b/SimWorks/chatlab/static/chatlab/css/simulation.css
@@ -77,6 +77,8 @@
     justify-content: space-between;
     gap: 0.5rem;
     align-items: center;
+    border-top: 1px solid var(--color-border);
+    cursor: pointer;
 }
 
 .sim-chat.collapsed {

--- a/SimWorks/simcore/templates/simcore/partials/tools/_wrapper.html
+++ b/SimWorks/simcore/templates/simcore/partials/tools/_wrapper.html
@@ -1,9 +1,14 @@
 {# templates/simcore/partials/tools/sidebar_wrapper.html #}
 {% load core_tags %}
 <!-- Simulation Tool: {{ tool.name }} -->
-<div id="{{ tool.name|lower }}-tool-header" class="metadata-header px-4">
-    <h3 class="medium">{{ tool.display_name }}</h3>
-    <button @click="toggle('{{ tool.name|lower }}')"
+<div id="{{ tool.name|lower }}-tool-header"
+     class="metadata-header px-4"
+     @click="toggle('{{ tool.name|lower }}')">
+    <h3 class="medium">
+        <span class="iconify" data-icon="material-symbols:menu-open-rounded" data-inline="true"></span>
+        {{ tool.display_name }}
+    </h3>
+    <button @click.stop="toggle('{{ tool.name|lower }}')"
             class="button primary small hide-small my-4"
             x-text="isOpen('{{ tool.name|lower }}') ? 'Hide' : 'Show'">
     </button>

--- a/SimWorks/simcore/templates/simcore/partials/tools/_wrapper.html
+++ b/SimWorks/simcore/templates/simcore/partials/tools/_wrapper.html
@@ -2,7 +2,7 @@
 {% load core_tags %}
 <!-- Simulation Tool: {{ tool.name }} -->
 <div id="{{ tool.name|lower }}-tool-header"
-     class="metadata-header px-4"
+     class="tool-header px-4"
      @click="toggle('{{ tool.name|lower }}')">
     <h3 class="medium">
         <span class="iconify" data-icon="material-symbols:menu-open-rounded" data-inline="true"></span>


### PR DESCRIPTION
Renames `metadata-header` to `tool-header` in line with updated project goals. Also allows for full-width click or touch on the `tool-header` to toggle display instead of just the button. This is mainly to enable toggling on mobile where the button is hidden.