### PR TITLE
Refactor Docker build process and update image tagging

### DIFF
--- a/.github/workflows/build-push-package.yml
+++ b/.github/workflows/build-push-package.yml
@@ -49,6 +49,39 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
+    - name: Build and push web image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile.prod
+        target: web
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:web-${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:web-latest
+
+    - name: Build and push celery image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile.prod
+        target: celery
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:celery-${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:celery-latest
+
+    - name: Build and push beat image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile.prod
+        target: beat
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:beat-${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:beat-latest
+
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v2
       with:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -46,6 +46,20 @@ RUN adduser --disabled-password --gecos "" --home "/nonexistent" \
     mkdir -p /app/static /app/media /app/logs && \
     chown -R appuser:appuser /app/static /app/media /app/logs
 
+# === Celery Worker Stage ===
+FROM base AS celery
+
+COPY SimWorks /app/SimWorks
+WORKDIR /app/SimWorks
+CMD ["celery", "-A", "config", "worker", "--loglevel=info"]
+
+# === Celery Beat Stage ===
+FROM base AS beat
+
+COPY SimWorks /app/SimWorks
+WORKDIR /app/SimWorks
+CMD ["celery", "-A", "config", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
+
 # === Web Stage (default) ===
 FROM base AS web
 
@@ -61,17 +75,3 @@ HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=10 CMD /app
 
 WORKDIR /app/SimWorks
 ENTRYPOINT ["/app/docker/entrypoint.dev.sh"]
-
-# === Celery Worker Stage ===
-FROM base AS celery
-
-COPY SimWorks /app/SimWorks
-WORKDIR /app/SimWorks
-CMD ["celery", "-A", "config", "worker", "--loglevel=info"]
-
-# === Celery Beat Stage ===
-FROM base AS beat
-
-COPY SimWorks /app/SimWorks
-WORKDIR /app/SimWorks
-CMD ["celery", "-A", "config", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -46,6 +46,20 @@ RUN adduser --disabled-password --gecos "" --home "/nonexistent" \
     mkdir -p /app/static /app/media /app/logs && \
     chown -R appuser:appuser /app/static /app/media /app/logs
 
+# === Celery Worker Stage ===
+FROM base AS celery
+
+COPY SimWorks /app/SimWorks
+WORKDIR /app/SimWorks
+CMD ["celery", "-A", "config", "worker", "--loglevel=info"]
+
+# === Celery Beat Stage ===
+FROM base AS beat
+
+COPY SimWorks /app/SimWorks
+WORKDIR /app/SimWorks
+CMD ["celery", "-A", "config", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
+
 # === Web Stage (default) ===
 FROM base AS web
 
@@ -61,17 +75,3 @@ HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=10 CMD /app
 
 WORKDIR /app/SimWorks
 ENTRYPOINT ["/app/docker/entrypoint.sh"]
-
-# === Celery Worker Stage ===
-FROM base AS celery
-
-COPY SimWorks /app/SimWorks
-WORKDIR /app/SimWorks
-CMD ["celery", "-A", "config", "worker", "--loglevel=info"]
-
-# === Celery Beat Stage ===
-FROM base AS beat
-
-COPY SimWorks /app/SimWorks
-WORKDIR /app/SimWorks
-CMD ["celery", "-A", "config", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/jackfruitco/simworks:${SERVER_IMAGE_TAG:-latest}
+    image: ghcr.io/jackfruitco/simworks:web-${SERVER_IMAGE_TAG:-latest}
     env_file:
       - stack.env
     expose:
@@ -11,7 +11,6 @@ services:
       - media-vol:/app/media
       # - nginx-conf:/app/nginx
       - /opt/www/logs:/app/logs
-    # command: ["/app/docker/entrypoint.prod.sh"]
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -83,7 +82,7 @@ services:
       - '${REDIS_PORT:-6379}'
 
   celery:
-    image: ghcr.io/jackfruitco/simworks:${SERVER_IMAGE_TAG:-latest}
+    image: ghcr.io/jackfruitco/simworks:celery-${SERVER_IMAGE_TAG:-latest}
     env_file:
       - stack.env
     environment:
@@ -115,7 +114,7 @@ services:
         max-file: "3"
 
   celerybeat:
-    image: ghcr.io/jackfruitco/simworks:${SERVER_IMAGE_TAG:-latest}
+    image: ghcr.io/jackfruitco/simworks:beat-${SERVER_IMAGE_TAG:-latest}
     env_file:
       - stack.env
     # user: appuser


### PR DESCRIPTION
### Summary of Changes

- Separated Docker image builds into distinct targets for web, celery, and beat services.
- Updated `compose.yaml` to reference newly tagged Docker images.
- Simplified the structure of `Dockerfile.prod` for improved maintainability.
- Adjusted GitHub Actions workflow to independently build and push the newly tagged images.

### Checklist

- [ ] Tests added or updated as required
- [ ] Documentation updated (if applicable)
- [ ] Changes are backward-compatible
- [ ] Code is reviewed and approved