### PR TITLE
Refactor and enhance CSRF error handling and templates

### DIFF
--- a/SimWorks/config/settings.py
+++ b/SimWorks/config/settings.py
@@ -90,6 +90,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.debug_flag",
             ],
         },
     },
@@ -225,3 +226,5 @@ logfire.instrument_httpx(
 )
 logfire.instrument_django(excluded_urls="/health(?:/|$)")
 logfire.instrument_openai(suppress_other_instrumentation=False)
+
+CSRF_FAILURE_VIEW = "core.views.csrf_failure"

--- a/SimWorks/core/context_processors.py
+++ b/SimWorks/core/context_processors.py
@@ -1,6 +1,8 @@
 # core/context_processors.py
 from django.conf import settings
 
+def debug_flag(request):
+    return {"debug": settings.DEBUG}
 
 def site_info(request):
     """

--- a/SimWorks/core/views.py
+++ b/SimWorks/core/views.py
@@ -4,7 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 from graphene_django.views import GraphQLView
-
+from opentelemetry import trace
 
 def index(request):
     # Number of visits to this view, as counted in the session variable.
@@ -35,6 +35,16 @@ class PrivateGraphQLView(GraphQLView):
             )
 
         return super().dispatch(request, *args, **kwargs)
+
+def csrf_failure(request, reason=""):
+    trace_id = None
+    span = trace.get_current_span()
+    if span and span.is_recording():
+        ctx = span.get_span_context()
+        trace_id = f"{ctx.trace_id:032x}"
+        span.set_attribute("django.csrf.reason", reason)
+
+    return render(request, "403_csrf.html", {"reason": reason, "trace_id": trace_id}, status=403)
 
 
 class RobotsView(TemplateView):

--- a/SimWorks/core/views/__init__.py
+++ b/SimWorks/core/views/__init__.py
@@ -1,0 +1,7 @@
+# core/views/__init__.py
+from .views import *
+from .failure_views import *
+
+__all__ = []
+__all__ += views.__all__
+__all__ += failure_views.__all__

--- a/SimWorks/core/views/failure_views.py
+++ b/SimWorks/core/views/failure_views.py
@@ -1,0 +1,17 @@
+# core/views/failure_views.py
+from django.shortcuts import render
+from opentelemetry import trace
+
+
+__all__ = ["csrf_failure"]
+
+
+def csrf_failure(request, reason=""):
+    trace_id = None
+    span = trace.get_current_span()
+    if span and span.is_recording():
+        ctx = span.get_span_context()
+        trace_id = f"{ctx.trace_id:032x}"
+        span.set_attribute("django.csrf.reason", reason)
+
+    return render(request, "403_csrf.html", {"reason": reason, "trace_id": trace_id}, status=403)

--- a/SimWorks/core/views/views.py
+++ b/SimWorks/core/views/views.py
@@ -1,10 +1,14 @@
+# core/views/views.py
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 from graphene_django.views import GraphQLView
-from opentelemetry import trace
+
+
+__all__ = ["index", "PrivateGraphQLView", "RobotsView"]
+
 
 def index(request):
     # Number of visits to this view, as counted in the session variable.
@@ -36,15 +40,6 @@ class PrivateGraphQLView(GraphQLView):
 
         return super().dispatch(request, *args, **kwargs)
 
-def csrf_failure(request, reason=""):
-    trace_id = None
-    span = trace.get_current_span()
-    if span and span.is_recording():
-        ctx = span.get_span_context()
-        trace_id = f"{ctx.trace_id:032x}"
-        span.set_attribute("django.csrf.reason", reason)
-
-    return render(request, "403_csrf.html", {"reason": reason, "trace_id": trace_id}, status=403)
 
 
 class RobotsView(TemplateView):

--- a/SimWorks/templates/403_csrf.html
+++ b/SimWorks/templates/403_csrf.html
@@ -4,6 +4,11 @@
     <div style="margin: 15vh 5vw;">
         <h1>Hmm... you aren't supposed to be here.</h1>
         <h3>Ready to head <a href="{% url 'home' %}">back home</a>?</h3>
-        <p>{{ reason }}</p>
+        {% if reason and debug %}
+            <p>{{ reason }}</p>
+        {% endif %}
+        {% if trace_id %}
+          <p>Reference ID <code>{{ trace_id|slice:":8" }}</code>.</p>
+        {% endif %}
     </div>
 {% endblock content %}


### PR DESCRIPTION
### Summary

This pull request refactors the CSRF failure handling by moving the CSRF failure view into its own module, ensuring better modularity and separation of concerns. Additionally, the `__init__.py` exports have been updated accordingly.

### Changes

- Extracted CSRF failure view into a dedicated module.
- Refined 403 and CSRF error templates, providing better context and debugging information.
- Added a new debug flag context processor in settings to assist with debugging CSRF failures.

### Checklist

- [ ] Ensure compatibility with existing CSRF configurations.
- [ ] Verify enhanced templates display appropriate debugging information.
- [ ] Confirm new modular setup works with settings.