### PR TITLE
Use Strawberry Info type in middleware

### DIFF
--- a/SimWorks/config/middleware.py
+++ b/SimWorks/config/middleware.py
@@ -1,16 +1,16 @@
 from graphql import GraphQLError
-from graphql import GraphQLResolveInfo as ResolveInfo
+from strawberry.types import Info
 
 
 class RequireApiPermissionMiddleware:
-    def resolve(self, next, root, info: ResolveInfo, **kwargs):
+    def resolve(self, next_, root, info: Info, **kwargs):
         # Whitelist any queries/mutations that don't require auth
         open_operations = {"tokenAuth", "verifyToken", "refreshToken"}
 
         if info.field_name in open_operations:
-            return next(root, info, **kwargs)
+            return next_(root, info, **kwargs)
 
         user = info.context.user
         if not user or not user.has_perm("core.read_api"):
             raise GraphQLError("Permission denied: `read_api` scope required.")
-        return next(root, info, **kwargs)
+        return next_(root, info, **kwargs)


### PR DESCRIPTION
## Summary
- switch GraphQL middleware to use `strawberry.types.Info`
- rename middleware `next` arg to avoid shadowing builtin

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71d33e124833381170858b445c082