### PR TITLE
Remove unused GraphQLError import

### DIFF
--- a/SimWorks/core/middleware.py
+++ b/SimWorks/core/middleware.py
@@ -1,9 +1,6 @@
 import json
 
 from django.http import HttpResponse
-from graphql import GraphQLError
-
-
 class HealthCheckMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response


### PR DESCRIPTION
## Summary
- remove leftover GraphQLError import from core middleware

## Testing
- `python -m ruff check SimWorks/core/middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68c71d3626688333a6b4ea3b7694461b