### PR TITLE
Adopt new settings loader without orchestrai.apps shim

### DIFF
--- a/packages/orchestrai/src/orchestrai/client/factory.py
+++ b/packages/orchestrai/src/orchestrai/client/factory.py
@@ -17,8 +17,7 @@ from .resolve import (
 )
 from .schemas import OrcaClientConfig, OrcaClientRegistration
 from .utils import effective_provider_config
-from ..apps.conf.loader import get_settings
-from ..apps.conf.models import OrcaSettings
+from .settings_loader import OrcaSettings, load_orca_settings
 from ..components.providerkit.conf_models import (
     ProvidersSettings,
     ProviderSettingsEntry,
@@ -169,7 +168,7 @@ def get_client(name: str | None = None):
       2) Otherwise, build a client from OrcaSettings (PROVIDERS/CLIENTS) and register it.
       3) If `name` is None, use OrcaSettings.DEFAULT_CLIENT.
     """
-    core = get_settings()
+    core = load_orca_settings()
 
     client_alias = name or getattr(core, "DEFAULT_CLIENT", "default")
 
@@ -204,7 +203,7 @@ def get_orca_client(
     if provider is None and profile is None:
         return get_client(client)
 
-    core = get_settings()
+    core = load_orca_settings()
     client_alias = client or getattr(core, "DEFAULT_CLIENT", "default")
 
     providers_settings: ProvidersSettings = core.PROVIDERS

--- a/packages/orchestrai/src/orchestrai/client/resolve.py
+++ b/packages/orchestrai/src/orchestrai/client/resolve.py
@@ -7,7 +7,7 @@ from ..components.providerkit.conf_models import (
     ProvidersSettings,
     ProviderSettingsEntry,
 )
-from ..apps.conf.models import OrcaSettings
+from .settings_loader import OrcaSettings
 
 
 def get_client_entry_or_default(

--- a/packages/orchestrai/src/orchestrai/client/settings_loader.py
+++ b/packages/orchestrai/src/orchestrai/client/settings_loader.py
@@ -1,0 +1,47 @@
+"""Settings loader for client/provider configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..conf.settings import Settings
+from ..components.providerkit.conf_models import ProvidersSettings
+from .conf_models import OrcaClientsSettings
+
+
+class OrcaSettings(BaseModel):
+    """Structured settings used by the client factory helpers."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    MODE: str = "single"
+    CLIENT: str | None = None
+    CLIENTS: OrcaClientsSettings = Field(default_factory=OrcaClientsSettings)
+    PROVIDERS: ProvidersSettings = Field(default_factory=ProvidersSettings)
+
+    DEFAULT_PROVIDER: str | None = None
+    DEFAULT_PROVIDER_PROFILE: str | None = None
+    DEFAULT_PROVIDER_API_KEY_ALIAS: str | None = None
+
+    @classmethod
+    def from_mapping(cls, mapping: dict | None = None) -> "OrcaSettings":
+        """Construct settings from an untyped mapping of config values."""
+
+        mapping = mapping or {}
+        return cls(**mapping)
+
+
+def load_orca_settings(mapping: dict | None = None) -> OrcaSettings:
+    """Load and normalize Orca settings using the modern settings layer."""
+
+    base = Settings()
+    base.update_from_object("orchestrai.settings")
+    base.update_from_envvar("ORCHESTRAI_CONFIG_MODULE")
+
+    if mapping:
+        base.update_from_mapping(mapping)
+
+    return OrcaSettings.from_mapping(base.as_dict())
+
+
+__all__ = ["load_orca_settings", "OrcaSettings"]

--- a/packages/orchestrai/src/orchestrai/identity/__init__.py
+++ b/packages/orchestrai/src/orchestrai/identity/__init__.py
@@ -13,7 +13,7 @@ from .identity import IdentityLike, Identity
 from .mixins import IdentityMixin
 from .resolvers import Resolve as _Resolve, IdentityResolver, resolve_identity
 from .protocols import IdentityResolverProtocol, IdentityProtocol
-from .utils import DEFAULT_IDENTITY_STRIP_TOKENS
+from .utils import DEFAULT_IDENTITY_STRIP_TOKENS, coerce_identity_key
 
 # Ergonomic namespace without coupling the dataclass to registries:
 Identity.resolve = _Resolve  # type: ignore[attr-defined]
@@ -23,6 +23,8 @@ __all__ = [
     "Identity", "IdentityLike", "IdentityResolver",
     # Constants
     "DEFAULT_IDENTITY_STRIP_TOKENS",
+    # Helpers
+    "coerce_identity_key",
     # Protocols
     "IdentityResolverProtocol", "IdentityProtocol",
 ]

--- a/packages/orchestrai/src/orchestrai/identity/utils.py
+++ b/packages/orchestrai/src/orchestrai/identity/utils.py
@@ -28,6 +28,8 @@ import re
 from collections.abc import Iterable, Callable
 from typing import Optional, Union, TYPE_CHECKING
 
+from .exceptions import IdentityError
+
 if TYPE_CHECKING:
     from . import IdentityLike, Identity
 
@@ -39,6 +41,7 @@ __all__ = [
     "resolve_collision",
     "parse_dot_identity",
     "get_effective_strip_tokens",
+    "coerce_identity_key",
 ]
 
 logger = logging.getLogger(__name__)
@@ -246,4 +249,21 @@ def parse_dot_identity(key: str) -> tuple[str, str, str]:
             f"Invalid identity '{key}': expected exactly three dot-separated parts."
         )
     return parts[0], parts[1], parts[2]
+
+
+def coerce_identity_key(value: "IdentityLike" | None) -> tuple[str, str, str] | None:
+    """Best-effort conversion of Identity-like inputs to an (namespace, kind, name) tuple."""
+
+    if value is None:
+        return None
+
+    try:
+        from .identity import Identity
+
+        ident = Identity.get(value)
+    except IdentityError:
+        logger.debug("Failed to coerce identity value: %r", value)
+        return None
+
+    return ident.as_tuple3
 

--- a/packages/orchestrai_django/src/orchestrai_django/__init__.py
+++ b/packages/orchestrai_django/src/orchestrai_django/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from orchestrai.apps import OrchestrAI, OrcaMode
+from orchestrai import OrchestrAI
 
-__all__ = ["OrchestrAI", "OrcaMode"]
+__all__ = ["OrchestrAI"]


### PR DESCRIPTION
## Summary
- remove the legacy `orchestrai.apps` compatibility package
- add a dedicated client settings loader built on the modern `orchestrai.conf.Settings`
- update client and Django integration code to consume the new loader and exports

## Testing
- pytest tests/orchestrai -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ede44b8788333be01ec493d235077)