### PR TITLE
Add AGENTS instructions for Django project and packages

### DIFF
--- a/SimWorks/AGENTS.md
+++ b/SimWorks/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENT INSTRUCTIONS — SimWorks Django project
+
+## Scope
+These instructions apply to the Django project in `SimWorks/` and any subdirectories unless a deeper `AGENTS.md` overrides them.
+
+## Development workflow
+- Use `uv run` for management commands (e.g., `uv run python manage.py migrate`, `uv run python manage.py runserver`).
+- Prefer `uv run pytest` for test execution; target specific apps or tests when possible to keep runs fast.
+- When changing models, run `uv run python manage.py makemigrations` and include generated migration files.
+
+## Coding guidance
+- Keep Django settings changes minimal and environment-agnostic; prefer settings driven by environment variables.
+- Favor explicit imports and avoid implicit side effects in module import time (no network calls during import).
+- Maintain consistent formatting for templates and static assets; keep template blocks minimal and readable.
+
+## Documentation
+- Update relevant docs in `PROJECT_OVERVIEW.md`, `docs/`, or app-level READMEs when behavior or workflows change.
+- Include concise notes in commit messages describing the Django-area change.

--- a/packages/orchestrai/AGENTS.md
+++ b/packages/orchestrai/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENT INSTRUCTIONS — OrchestrAI package
+
+## Scope
+These instructions cover the OrchestrAI library under `packages/orchestrai/` (including `src/orchestrai/` and docs).
+
+## Development workflow
+- Run the package test suite with `uv run pytest packages/orchestrai` from the repo root.
+- Keep the public API stable; add exports through `__init__.py` when introducing new components.
+- Avoid introducing import-time side effects—lifecycle steps should remain explicit.
+
+## Coding guidance
+- Prefer clear lifecycle naming (`configure()`, `setup()`, `discover()`, `finalize()`, `start()`).
+- Keep registries predictable: validate keys early and surface helpful errors for collisions.
+- Document new behaviors in `packages/orchestrai/docs/` when adding or changing workflow steps.
+
+## Documentation
+- Update `packages/orchestrai/README.md` if usage or installation changes.
+- Note meaningful library changes in commit messages so downstream projects can track updates.

--- a/packages/orchestrai_django/AGENTS.md
+++ b/packages/orchestrai_django/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENT INSTRUCTIONS — OrchestrAI Django integration
+
+## Scope
+Applies to the Django integration package in `packages/orchestrai_django/`, including `src/orchestrai_django/` and docs.
+
+## Development workflow
+- Run tests from the repo root with `uv run pytest packages/orchestrai_django`.
+- Keep Django wiring explicit: registrations and signal emitters should not fire at import time unless necessary for Django app loading.
+- Align examples and docs with the current package name and API surface.
+
+## Coding guidance
+- Validate tuple³ identities (`origin.bucket.name`) before registry insertion; raise clear errors on collisions.
+- Prefer decorators (`@llm_service`, `@codec`, `@prompt_section`) for registrations and keep them idempotent.
+- When adding execution helpers, ensure synchronous and asynchronous paths stay consistent.
+
+## Documentation
+- Update `packages/orchestrai_django/docs/` and README quick starts when behavior changes.
+- Mention integration-impacting changes in commit messages so downstream projects stay aligned.


### PR DESCRIPTION
## Summary
- add AGENTS.md guidance for the SimWorks Django project
- document package-specific workflow instructions for orchestrai
- add Django integration package guidance for orchestrai_django

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f12005258833385f1c9acff4a2999)