### PR TITLE
Add push and PR triggers to build-push workflow

### DIFF
--- a/.github/workflows/build-push-package.yml
+++ b/.github/workflows/build-push-package.yml
@@ -4,6 +4,14 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- run the Docker image workflow on pushes to main and version tags
- allow optional pull request runs targeting main to build images continuously

## Testing
- not run (not necessary)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f180209d08333bce527e1def3e783)