### PR TITLE
Configure shared Buildx cache for package images

### DIFF
--- a/.github/workflows/build-push-package.yml
+++ b/.github/workflows/build-push-package.yml
@@ -46,6 +46,8 @@ jobs:
         context: .
         file: docker/Dockerfile.prod
         push: true
+        cache-from: type=gha,mode=max,scope=package-build-cache
+        cache-to: type=gha,mode=max,scope=package-build-cache
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
@@ -56,6 +58,8 @@ jobs:
         file: docker/Dockerfile.prod
         target: web
         push: true
+        cache-from: type=gha,mode=max,scope=package-build-cache
+        cache-to: type=gha,mode=max,scope=package-build-cache
         tags: |
           ghcr.io/${{ github.repository }}:web-${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:web-latest
@@ -68,6 +72,8 @@ jobs:
         file: docker/Dockerfile.prod
         target: celery
         push: true
+        cache-from: type=gha,mode=max,scope=package-build-cache
+        cache-to: type=gha,mode=max,scope=package-build-cache
         tags: |
           ghcr.io/${{ github.repository }}:celery-${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:celery-latest
@@ -80,6 +86,8 @@ jobs:
         file: docker/Dockerfile.prod
         target: beat
         push: true
+        cache-from: type=gha,mode=max,scope=package-build-cache
+        cache-to: type=gha,mode=max,scope=package-build-cache
         tags: |
           ghcr.io/${{ github.repository }}:beat-${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:beat-latest


### PR DESCRIPTION
## Summary
- configure all Docker build steps to use the GitHub Actions cache backend
- share the cache scope across default, web, celery, and beat targets to maximize layer reuse

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f181240608333bd0ba98f185293cf)