### PR TITLE
Add coverage configuration and test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Run tests with coverage
+        run: uv run pytest
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore
+          retention-days: 7

--- a/checks.md
+++ b/checks.md
@@ -20,3 +20,8 @@ docker compose -f docker/compose.dev.yaml run --rm server python manage.py ai_he
 
 #### Run
 - `docker compose -f docker/compose.dev.yaml up`
+
+#### Tests and coverage
+- `uv run pytest`
+  - Generates `coverage.xml` and a terminal summary via pytest-cov.
+  - Fails if overall coverage drops below 80%.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,12 @@ orchestrai = { workspace = true }
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"
 python_files = ["tests/*.py", "tests/**/*.py"]
-addopts = "-ra -q"
+addopts = [
+    "-ra",
+    "--cov=SimWorks",
+    "--cov=packages/orchestrai/src/orchestrai",
+    "--cov=packages/orchestrai_django/src/orchestrai_django",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-fail-under=80",
+]


### PR DESCRIPTION
## Summary
- configure pytest to collect coverage across SimWorks and workspace packages with XML and terminal reports
- document coverage threshold expectations in project checks
- add CI workflow to run pytest with coverage and upload the XML report

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f18e694348333b2d808075ce841ab)