### PR TITLE
Refine Docker base user and ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Version control
+.git
+.github
+
+# Python caches
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+
+# Environment and virtualenvs
+*.env
+.venv
+.tox
+
+# Build artifacts
+build
+dist
+*.egg-info
+
+# Test outputs
+.pytest_cache
+
+# Editor files
+.vscode
+.idea
+*.swp
+*.swo
+.DS_Store
+
+# Documentation and exports
+/docs
+notes

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -21,9 +21,6 @@ ENV UV_COMPILE_BYTECODE=1 \
     UV_NO_EDITABLE=1
 
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
 # Copy local packages
 COPY packages ./packages
 
@@ -55,7 +52,14 @@ ARG UID=10001
 RUN adduser --disabled-password --gecos "" --home "/nonexistent" \
     --shell "/sbin/nologin" --no-create-home --uid "${UID}" appuser && \
     mkdir -p /app/static /app/media /app/logs && \
-    chown -R appuser:appuser /app/static /app/media /app/logs
+    chown -R appuser:appuser /app
+
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER appuser
 
 # === Celery Worker Stage ===
 FROM base AS celery
@@ -78,8 +82,6 @@ COPY SimWorks /app/SimWorks
 COPY docker/entrypoint.dev.sh /app/docker/entrypoint.sh
 COPY docker/healthcheck.sh /app/docker/healthcheck.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN chmod +x /app/docker/*.sh
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=12 CMD /app/docker/healthcheck.sh

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -19,9 +19,6 @@ ENV UV_COMPILE_BYTECODE=1 \
     UV_PROJECT_ENVIRONMENT=/usr/local \
     UV_NO_EDITABLE=1
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
 # Copy local packages
 COPY packages ./packages
 
@@ -48,7 +45,14 @@ ARG UID=10001
 RUN adduser --disabled-password --gecos "" --home "/nonexistent" \
     --shell "/sbin/nologin" --no-create-home --uid "${UID}" appuser && \
     mkdir -p /app/static /app/media /app/logs && \
-    chown -R appuser:appuser /app/static /app/media /app/logs
+    chown -R appuser:appuser /app
+
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER appuser
 
 # === Celery Worker Stage ===
 FROM base AS celery
@@ -71,8 +75,6 @@ COPY SimWorks /app/SimWorks
 COPY docker/entrypoint.prod.sh /app/docker/entrypoint.sh
 COPY docker/healthcheck.sh /app/docker/healthcheck.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN chmod +x /app/docker/*.sh
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=10 CMD /app/docker/healthcheck.sh


### PR DESCRIPTION
## Summary
- add appuser to base images, adjust ownership, and ensure derived stages run unprivileged
- centralize curl installation in the base stage with apt cache mounts to avoid repeated installs
- add a root-level .dockerignore to keep VCS, caches, build artifacts, and docs out of build context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f191820488333bd947b5d9b2236d4)