### PR TITLE
Harden Docker entrypoints and services

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -89,8 +89,7 @@ services:
       - stack.env
     environment:
       - PYTHONPATH=/app/SimWorks
-    # user: appuser
-    user: root
+    user: appuser
     # command: [ "celery", "-A", "config", "worker", "--loglevel=info" ]
     depends_on:
       redis:
@@ -123,6 +122,7 @@ services:
     environment:
       - PYTHONPATH=/app/SimWorks
     # command: [ "celery", "-A", "config", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler" ]
+    user: appuser
     volumes:
       - static-vol:/app/static
       - media-vol:/app/media

--- a/docker/entrypoint.dev.sh
+++ b/docker/entrypoint.dev.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Set Django settings module
 export DJANGO_SETTINGS_MODULE=config.settings
 
@@ -50,4 +52,4 @@ fi
 # Start server
 echo
 echo "Starting daphne server..."
-daphne -b 0.0.0.0 -p 8000 --access-log /dev/null config.asgi:application
+exec daphne -b 0.0.0.0 -p 8000 --access-log /dev/null config.asgi:application

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Set Django settings module
 export DJANGO_SETTINGS_MODULE=config.settings
 
@@ -31,4 +33,4 @@ UserRole.objects.exists() or UserRole.objects.bulk_create([ \
 # Start server
 echo
 echo "Starting daphne server..."
-daphne -b 0.0.0.0 -p 8000 config.asgi:application
+exec daphne -b 0.0.0.0 -p 8000 config.asgi:application

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -2,7 +2,7 @@
 export DJANGO_SKIP_READY=1
 
 # Check if Django server is responding
-if curl -fs http://localhost:8000/health > /dev/null; then
+if curl -fs --max-time 3 http://localhost:8000/health > /dev/null; then
     echo "Healthcheck passed."
     exit 0
 else


### PR DESCRIPTION
## Summary
- add strict bash options and exec to daphne entrypoints
- drop celery service privileges to the appuser
- tighten healthcheck curl to fail quickly on stalled connections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1a5291f883339f75246cf2af12a0)