### PR TITLE
Expect decode error for invalid OpenAI response payload

### DIFF
--- a/tests/orchestrai/components/codecs/openai/test_responses_json_codec.py
+++ b/tests/orchestrai/components/codecs/openai/test_responses_json_codec.py
@@ -126,8 +126,8 @@ def test_decode_with_invalid_payload_raises_codecdecodeerror():
     payload = {"foo": "not_an_int"}
     resp = _make_response_with_structured_payload(payload, IntSchema)
 
-    result = codec.decode(resp)
-    assert isinstance(result, IntSchema)
+    with pytest.raises(CodecDecodeError):
+        codec.decode(resp)
 
 
 def test_decode_prefers_provider_structured_over_text_json():


### PR DESCRIPTION
## Summary
- update the invalid payload test for OpenAIResponsesJsonCodec to expect CodecDecodeError during decode

## Testing
- pytest tests/orchestrai/components/codecs/openai/test_responses_json_codec.py -q (fails: codec currently does not raise CodecDecodeError)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1ef90ad88333aee0981f74fa5d39)