### PR TITLE
Add ComponentRegistry for identity-keyed components

### DIFF
--- a/packages/orchestrai/src/orchestrai/components/base.py
+++ b/packages/orchestrai/src/orchestrai/components/base.py
@@ -8,7 +8,7 @@ from .exceptions import ComponentNotFoundError
 from ..identity import IdentityLike
 
 if TYPE_CHECKING:
-    from orchestrai.registry import BaseRegistry
+    from orchestrai.registry import ComponentRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class BaseComponent(ABC):
     # Registry accessors
     # ----------------------------------------------------------------------------------
     @classmethod
-    def get_registry(cls) -> BaseRegistry:
+    def get_registry(cls) -> "ComponentRegistry":
         from orchestrai.registry.singletons import get_registry_for
 
         registry = get_registry_for(cls)
@@ -43,11 +43,11 @@ class BaseComponent(ABC):
         return registry
 
     @classmethod
-    async def aget_registry(cls) -> BaseRegistry:
+    async def aget_registry(cls) -> "ComponentRegistry":
         return cls.get_registry()
 
     @classmethod
-    def try_get_registry(cls) -> BaseRegistry | None:
+    def try_get_registry(cls) -> "ComponentRegistry" | None:
         """Return the registry for this component class, or None if not available."""
         from ..registry.exceptions import RegistryNotFoundError
 

--- a/packages/orchestrai/src/orchestrai/decorators/components/codec_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/codec_decorator.py
@@ -10,7 +10,7 @@ Core codec decorator.
 import logging
 from typing import Any, Type, TypeVar
 
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 from orchestrai.decorators.base import BaseDecorator
 from orchestrai.components.codecs.codec import BaseCodec
 from orchestrai.registry.singletons import codecs as codec_registry
@@ -40,7 +40,7 @@ class CodecDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         """Return the global codecs registry singleton."""
         return codec_registry
 

--- a/packages/orchestrai/src/orchestrai/decorators/components/prompt_section_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/prompt_section_decorator.py
@@ -12,7 +12,7 @@ from typing import Any, Type, TypeVar
 
 from orchestrai.components.promptkit import PromptSection
 from orchestrai.decorators.base import BaseDecorator
-from orchestrai.registry.base import BaseRegistry
+from orchestrai.registry.base import ComponentRegistry
 from orchestrai.registry.singletons import prompt_sections as _Registry
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class PromptSectionDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         return _Registry
 
     def register(self, candidate: Type[Any]) -> None:

--- a/packages/orchestrai/src/orchestrai/decorators/components/provider_decorators.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/provider_decorators.py
@@ -15,7 +15,7 @@ from typing import Any, Type
 
 from orchestrai.components.providerkit import BaseProvider
 from orchestrai.decorators.base import BaseDecorator
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 from orchestrai.registry.singletons import (
     provider_backends as provider_backend_registry,
     providers as providers_registry,
@@ -44,7 +44,7 @@ class ProviderBackendDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         """Return the global provider backends registry singleton (identity-keyed)."""
         return provider_backend_registry
 
@@ -78,7 +78,7 @@ class ProviderDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         """Return the global providers registry singleton (identity-keyed)."""
         return providers_registry
 

--- a/packages/orchestrai/src/orchestrai/decorators/components/schema_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/schema_decorator.py
@@ -1,6 +1,6 @@
 
 
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 
 """
 Core codec decorator.
@@ -40,7 +40,7 @@ class SchemaDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         # Always register into the schema registry
         return schema_registry
 

--- a/packages/orchestrai/src/orchestrai/decorators/components/service_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/service_decorator.py
@@ -1,7 +1,7 @@
 # orchestrai/decorators/components/service_decorator.py
 
 
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 
 """
 Core service decorator.
@@ -41,7 +41,7 @@ class ServiceDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         # Always register into the service registry
         return _Registry
 

--- a/packages/orchestrai/src/orchestrai/registry/__init__.py
+++ b/packages/orchestrai/src/orchestrai/registry/__init__.py
@@ -1,13 +1,14 @@
 """Lightweight registries."""
 from __future__ import annotations
 
-from .base import BaseRegistry
+from .base import BaseRegistry, ComponentRegistry
 from .simple import Registry
 from .singletons import codecs, prompt_sections, provider_backends, providers
 
 __all__ = [
     "Registry",
     "BaseRegistry",
+    "ComponentRegistry",
     "provider_backends",
     "providers",
     "codecs",

--- a/packages/orchestrai/src/orchestrai/registry/base.py
+++ b/packages/orchestrai/src/orchestrai/registry/base.py
@@ -8,6 +8,7 @@ from typing import Callable, Generic, TypeVar, Any, overload, Literal
 from asgiref.sync import sync_to_async
 
 from .exceptions import RegistryDuplicateError, RegistryCollisionError, RegistryFrozenError, RegistryLookupError
+from ..identity.identity import Identity
 from ..components.exceptions import ComponentNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -273,3 +274,10 @@ class BaseRegistry(Generic[K, T]):
         Async: mark the registry as frozen (no further mutations).
         """
         return await sync_to_async(self.freeze)()
+
+
+class ComponentRegistry(BaseRegistry[Identity, T]):
+    """Registry specialized for Identity-keyed component classes."""
+
+    def __init__(self) -> None:
+        super().__init__(coerce_key=Identity.get_for)

--- a/packages/orchestrai/src/orchestrai/registry/singletons.py
+++ b/packages/orchestrai/src/orchestrai/registry/singletons.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload, cast, TypeAlias
 
 from orchestrai.identity.identity import Identity
-from orchestrai.registry.base import BaseRegistry
+from orchestrai.registry.base import ComponentRegistry
 
 if TYPE_CHECKING:
     # Only imported for typing; avoids runtime circular imports.
@@ -39,48 +39,46 @@ if TYPE_CHECKING:
 
 
     @overload
-    def get_registry_for(component: type[TSvc]) -> BaseRegistry[Identity, TSvc]:
+    def get_registry_for(component: type[TSvc]) -> ComponentRegistry[TSvc]:
         ...
 
 
     @overload
-    def get_registry_for(component: type[TCod]) -> BaseRegistry[Identity, TCod]:
+    def get_registry_for(component: type[TCod]) -> ComponentRegistry[TCod]:
         ...
 
 
     @overload
-    def get_registry_for(component: type[TSch]) -> BaseRegistry[Identity, TSch]:
+    def get_registry_for(component: type[TSch]) -> ComponentRegistry[TSch]:
         ...
 
 
     @overload
-    def get_registry_for(component: type[TPS]) -> BaseRegistry[Identity, TPS]:
+    def get_registry_for(component: type[TPS]) -> ComponentRegistry[TPS]:
         ...
 
 
     @overload
-    def get_registry_for(component: type[TPrv]) -> BaseRegistry[Identity, TPrv]:
+    def get_registry_for(component: type[TPrv]) -> ComponentRegistry[TPrv]:
         ...
 
 
     @overload
-    def get_registry_for(kind: ComponentKind) -> BaseRegistry[Identity, Any]:
+    def get_registry_for(kind: ComponentKind) -> ComponentRegistry[Any]:
         ...
 else:
     # At runtime we don’t need precise typing – keep it loose.
     ComponentKind = str  # type: ignore[assignment]
     ComponentKey = Any  # type: ignore[assignment]
 
-_coerce = Identity.get_for
-
 # Global registries keyed by Identity.
-services: BaseRegistry[Identity, Any] = BaseRegistry(coerce_key=_coerce)
-codecs: BaseRegistry[Identity, Any] = BaseRegistry(coerce_key=_coerce)
-schemas: BaseRegistry[Identity, Any] = BaseRegistry(coerce_key=_coerce)
-prompt_sections: BaseRegistry[Identity, Any] = BaseRegistry(coerce_key=_coerce)
+services: ComponentRegistry[Any] = ComponentRegistry()
+codecs: ComponentRegistry[Any] = ComponentRegistry()
+schemas: ComponentRegistry[Any] = ComponentRegistry()
+prompt_sections: ComponentRegistry[Any] = ComponentRegistry()
 
-provider_backends: BaseRegistry[Identity, Any] = BaseRegistry(coerce_key=_coerce)
-providers: BaseRegistry[Identity, Any] = BaseRegistry(coerce_key=_coerce)
+provider_backends: ComponentRegistry[Any] = ComponentRegistry()
+providers: ComponentRegistry[Any] = ComponentRegistry()
 
 
 def _infer_kind_from_type(component_type: type[Any]) -> str | None:
@@ -124,7 +122,7 @@ def _infer_kind_from_type(component_type: type[Any]) -> str | None:
     return None
 
 
-def get_registry_for(component: ComponentKeyLike) -> BaseRegistry[Identity, Any] | None:
+def get_registry_for(component: ComponentKeyLike) -> ComponentRegistry[Any] | None:
     """
     Return the global registry singleton corresponding to the given component.
 
@@ -154,14 +152,14 @@ def get_registry_for(component: ComponentKeyLike) -> BaseRegistry[Identity, Any]
             return None
 
     if kind == "service":
-        return cast(BaseRegistry[Identity, Any], services)
+        return cast(ComponentRegistry[Any], services)
     if kind == "codec":
-        return cast(BaseRegistry[Identity, Any], codecs)
+        return cast(ComponentRegistry[Any], codecs)
     if kind == "schema":
-        return cast(BaseRegistry[Identity, Any], schemas)
+        return cast(ComponentRegistry[Any], schemas)
     if kind == "prompt_section":
-        return cast(BaseRegistry[Identity, Any], prompt_sections)
+        return cast(ComponentRegistry[Any], prompt_sections)
     if kind == "backend":
-        return cast(BaseRegistry[Identity, Any], provider_backends)
+        return cast(ComponentRegistry[Any], provider_backends)
 
     return None

--- a/packages/orchestrai_django/src/orchestrai_django/decorators/components/codec_decorator.py
+++ b/packages/orchestrai_django/src/orchestrai_django/decorators/components/codec_decorator.py
@@ -1,6 +1,6 @@
 
 
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 from orchestrai_django.decorators import DjangoBaseDecorator
 
 """
@@ -43,7 +43,7 @@ class DjangoCodecDecorator(DjangoBaseDecorator):
     """
     default_kind = "default"
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         # Always register into the codecs registry
         return codec_registry
 

--- a/packages/orchestrai_django/src/orchestrai_django/decorators/components/prompt_section_decorator.py
+++ b/packages/orchestrai_django/src/orchestrai_django/decorators/components/prompt_section_decorator.py
@@ -12,7 +12,7 @@ from typing import Any, Type, TypeVar
 
 from orchestrai.components.promptkit import PromptSection
 from orchestrai_django.decorators import DjangoBaseDecorator
-from orchestrai.registry.base import BaseRegistry
+from orchestrai.registry.base import ComponentRegistry
 from orchestrai.registry.singletons import prompt_sections
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class DjangoPromptSectionDecorator(DjangoBaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         return prompt_sections
 
     def register(self, candidate: Type[Any]) -> None:

--- a/packages/orchestrai_django/src/orchestrai_django/decorators/components/schema_decorator.py
+++ b/packages/orchestrai_django/src/orchestrai_django/decorators/components/schema_decorator.py
@@ -1,6 +1,6 @@
 
 
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 
 """
 Core codec decorator.
@@ -40,7 +40,7 @@ class DjangoSchemaDecorator(BaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         # Always register into the schema registry
         return _Registry
 

--- a/packages/orchestrai_django/src/orchestrai_django/decorators/components/service_decorator.py
+++ b/packages/orchestrai_django/src/orchestrai_django/decorators/components/service_decorator.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any, Type, TypeVar
 
 from orchestrai.components.services.service import BaseService
-from orchestrai.registry import BaseRegistry
+from orchestrai.registry import ComponentRegistry
 from orchestrai.registry.singletons import services as _Registry
 from orchestrai_django.decorators.base import DjangoBaseDecorator
 
@@ -47,7 +47,7 @@ class DjangoServiceDecorator(DjangoBaseDecorator):
             ...
     """
 
-    def get_registry(self) -> BaseRegistry:
+    def get_registry(self) -> ComponentRegistry:
         # Always register into the service registry
         return _Registry
 


### PR DESCRIPTION
## Summary
- add a ComponentRegistry subclass that fixes Identity.get_for coercion for component registries
- update registry singletons and component decorators to use the specialized registry
- align Django integration decorators with the new registry type

## Testing
- uv run pytest packages/orchestrai -q *(fails: openai dependency download blocked by network access)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3676d7688333b6884ac4ea7f0ed3)