### PR TITLE
Handle registry missing key lookups gracefully

### DIFF
--- a/packages/orchestrai/src/orchestrai/registry/base.py
+++ b/packages/orchestrai/src/orchestrai/registry/base.py
@@ -9,7 +9,6 @@ from asgiref.sync import sync_to_async
 
 from .exceptions import RegistryDuplicateError, RegistryCollisionError, RegistryFrozenError, RegistryLookupError
 from ..identity.identity import Identity
-from ..components.exceptions import ComponentNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +82,7 @@ class BaseRegistry(Generic[K, T]):
     def get(self, key: Any) -> type[T]:
         """
         Retrieve a component associated with the given key from the store. If
-        the key does not exist in the store, a `ComponentNotFoundError` is
+        the key does not exist in the store, a `RegistryLookupError` is
         raised.
 
         The method safely handles concurrent access to the store using a lock,
@@ -117,7 +116,7 @@ class BaseRegistry(Generic[K, T]):
         """
         Attempts to retrieve a value associated with the given key from the object,
         returning None if the key is not found. This method leverages the `get`
-        function and handles the `ComponentNotFoundError` exception internally.
+        function and handles the `RegistryLookupError` exception internally.
 
         :param key: The key to retrieve a value for.
         :type key: Any
@@ -126,7 +125,7 @@ class BaseRegistry(Generic[K, T]):
         """
         try:
             return self.get(key)
-        except ComponentNotFoundError:
+        except RegistryLookupError:
             return None
 
     async def atry_get(self, key: Any) -> type[T] | None:
@@ -136,7 +135,7 @@ class BaseRegistry(Generic[K, T]):
         """
         try:
             return await self.aget(key)
-        except ComponentNotFoundError:
+        except RegistryLookupError:
             return None
 
     # --- counting ---

--- a/tests/orchestrai/test_state_and_proxy.py
+++ b/tests/orchestrai/test_state_and_proxy.py
@@ -1,3 +1,4 @@
+import asyncio
 import types
 
 import pytest
@@ -42,3 +43,15 @@ def test_registry_freeze_blocks_registration():
 
     with pytest.raises(RuntimeError):
         reg.register("two", 2)
+
+
+def test_registry_try_get_returns_none_for_missing_key():
+    reg = Registry()
+
+    assert reg.try_get("missing") is None
+
+
+def test_registry_atry_get_returns_none_for_missing_key():
+    reg = Registry()
+
+    assert asyncio.run(reg.atry_get("missing")) is None


### PR DESCRIPTION
## Summary
- catch registry lookup errors in try_get helpers so missing keys return None
- add regression tests covering missing registry lookups for sync and async helpers

## Testing
- uv run pytest packages/orchestrai *(fails: dependency download blocked by network)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f39df5088833395fc779154372430)