### PR TITLE
Initialize registry finalize callbacks

### DIFF
--- a/packages/orchestrai/src/orchestrai/registry/simple.py
+++ b/packages/orchestrai/src/orchestrai/registry/simple.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterator
+from typing import Any, Callable, Dict, Iterator, Sequence
 
 from orchestrai.components.services.service import BaseService
 from orchestrai.registry.base import BaseRegistry
@@ -16,6 +16,7 @@ def _coerce_to_str(value: Any) -> str:
 class Registry(BaseRegistry[str, Any]):
     def __init__(self) -> None:
         super().__init__(coerce_key=_coerce_to_str)
+        self._finalize_callbacks: list[Callable[[Any], None]] = []
 
     def register(self, name: str, obj: Any) -> None:
         key = self._coerce(name)

--- a/tests/orchestrai/test_registry_simple.py
+++ b/tests/orchestrai/test_registry_simple.py
@@ -1,0 +1,29 @@
+from orchestrai.registry.simple import Registry
+
+
+def test_finalize_callbacks_registered_and_invoked_with_app():
+    registry = Registry()
+    calls = []
+
+    def callback(app):
+        calls.append(app)
+
+    returned = registry.add_finalize_callback(callback)
+
+    assert returned is callback
+    registry.finalize(app="sentinel-app")
+
+    assert calls == ["sentinel-app"]
+    assert registry._frozen is True
+
+
+def test_finalize_defaults_to_registry_when_no_app_provided():
+    registry = Registry()
+    captured = []
+
+    registry.add_finalize_callback(lambda app: captured.append(app))
+
+    registry.finalize()
+
+    assert captured == [registry]
+    assert registry._frozen is True


### PR DESCRIPTION
## Summary
- initialize a finalize callback collection for the simple registry
- invoke stored callbacks during registry finalization
- add tests covering callback registration and execution paths

## Testing
- uv run pytest packages/orchestrai *(fails: unable to download psycopg-binary)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f39e064d883338bfdc590bf15ef56)