### PR TITLE
Rename app registries for clarity

### DIFF
--- a/packages/orchestrai/src/orchestrai/app.py
+++ b/packages/orchestrai/src/orchestrai/app.py
@@ -42,7 +42,7 @@ from .finalize import consume_finalizers
 from .fixups.base import BaseFixup
 from .loaders.base import BaseLoader
 from .registry.base import BaseRegistry
-from .registry.simple import Registry, ServicesRegistry
+from .registry.simple import AppRegistry, ServiceRunnerRegistry
 
 
 # ---------------------------------------------------------------------------
@@ -76,11 +76,11 @@ class OrchestrAI:
     _local_finalize_callbacks: list[Callable[["OrchestrAI"], None]] = field(default_factory=list)
     _fixup_specs: list[object] = field(default_factory=list, repr=False)
 
-    services: ServicesRegistry = field(default_factory=ServicesRegistry)
-    codecs: Registry = field(default_factory=Registry)
-    providers: Registry = field(default_factory=Registry)
-    clients: Registry = field(default_factory=Registry)
-    prompt_sections: Registry = field(default_factory=Registry)
+    services: ServiceRunnerRegistry = field(default_factory=ServiceRunnerRegistry)
+    codecs: AppRegistry = field(default_factory=AppRegistry)
+    providers: AppRegistry = field(default_factory=AppRegistry)
+    clients: AppRegistry = field(default_factory=AppRegistry)
+    prompt_sections: AppRegistry = field(default_factory=AppRegistry)
 
     def __post_init__(self) -> None:
         # Capture any provided fixup specs; actual instances are built during setup

--- a/packages/orchestrai/src/orchestrai/registry/__init__.py
+++ b/packages/orchestrai/src/orchestrai/registry/__init__.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from .base import BaseRegistry, ComponentRegistry
-from .simple import Registry
+from .simple import AppRegistry
 from .singletons import codecs, prompt_sections, provider_backends, providers
 
 __all__ = [
-    "Registry",
+    "AppRegistry",
     "BaseRegistry",
     "ComponentRegistry",
     "provider_backends",

--- a/packages/orchestrai/src/orchestrai/registry/simple.py
+++ b/packages/orchestrai/src/orchestrai/registry/simple.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterator
+from typing import Any, Callable, Dict, Iterator, Sequence
 
 from orchestrai.components.services.service import BaseService
 from orchestrai.registry.base import BaseRegistry
@@ -13,9 +13,10 @@ def _coerce_to_str(value: Any) -> str:
     return str(value)
 
 
-class Registry(BaseRegistry[str, Any]):
+class AppRegistry(BaseRegistry[str, Any]):
     def __init__(self) -> None:
         super().__init__(coerce_key=_coerce_to_str)
+        self._finalize_callbacks: list[Callable[[Any], None]] = []
 
     def register(self, name: str, obj: Any) -> None:
         key = self._coerce(name)
@@ -60,7 +61,7 @@ class Registry(BaseRegistry[str, Any]):
         return iter(self._store.items())
 
 
-class ServicesRegistry(Registry):
+class ServiceRunnerRegistry(AppRegistry):
     """Registry with helpers to run registered services.
 
     Exposes convenience methods that mirror the old ``Service.task`` helpers:


### PR DESCRIPTION
## Summary
- rename the lightweight Registry to AppRegistry and initialize its finalize callbacks
- rename ServicesRegistry to ServiceRunnerRegistry and wire OrchestrAI to the new names
- update registry exports to reflect the new AppRegistry name

## Testing
- uv run pytest packages/orchestrai *(fails: celery dependency download blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3973cce88333b2bb62b209421755)