### PR TITLE
Ensure autostarted OrchestrAI app is set as current

### DIFF
--- a/SimWorks/config/orca.py
+++ b/SimWorks/config/orca.py
@@ -6,6 +6,7 @@ from orchestrai_django.integration import configure_from_django_settings
 
 app = OrchestrAI()
 configure_from_django_settings(app)
+app.set_as_current()
 app.start()
 
 


### PR DESCRIPTION
## Summary
- set the Django orca app as the current OrchestrAI instance before starting so autostart reuses it
- ensure Django autostart registers the resolved app on both settings and the current-app context
- add a management command test covering autostart plus run_service registry visibility and component reporting

## Testing
- uv run pytest tests/orchestrai_django/test_management_commands.py *(fails: unable to download opentelemetry-sdk dependency in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f44afec348333a192676041505ca9)