### PR TITLE
Fix patient prompt simulation resolution

### DIFF
--- a/SimWorks/simulation/orca/prompts/sections/patient.py
+++ b/SimWorks/simulation/orca/prompts/sections/patient.py
@@ -20,10 +20,13 @@ class PatientNameSection(SimcoreMixin, StandardizedPatientMixin, PromptSection):
     async def render_instruction(self, **ctx) -> str | None:
         options_ = ("simulation_id", "simulation", "sim_id", "sim_pk", "sim_obj")
 
+        simulation_ = None
         for opt in options_:
-            if simulation_ := opt in ctx:
+            simulation_ = ctx.get(opt)
+            if simulation_:
                 break
-        else:
+
+        if simulation_ is None and not any(opt in ctx for opt in options_):
             raise ValueError(f"Missing required context variable(s): {options_}")
 
         if not isinstance(simulation_, Simulation):

--- a/tests/simworks/test_patient_prompt_section.py
+++ b/tests/simworks/test_patient_prompt_section.py
@@ -1,0 +1,66 @@
+import importlib
+import sys
+import types
+
+import pytest
+from django.core.exceptions import ObjectDoesNotExist
+
+
+class DummyManager:
+    def __init__(self, simulation):
+        self.simulation = simulation
+
+    async def aget(self, pk):
+        if pk == self.simulation.pk:
+            return self.simulation
+        raise ObjectDoesNotExist
+
+
+class DummySimulation:
+    def __init__(self, pk: int, full_name: str):
+        self.pk = pk
+        self.sim_patient_full_name = full_name
+
+
+@pytest.fixture()
+def patient_module(monkeypatch):
+    simulation = DummySimulation(pk=101, full_name="Jamie Patient")
+    DummySimulation.objects = DummyManager(simulation)
+
+    dummy_models = types.SimpleNamespace(Simulation=DummySimulation)
+    monkeypatch.setitem(sys.modules, "simulation.models", dummy_models)
+    sys.modules.pop("simulation.orca.prompts.sections.patient", None)
+
+    module = importlib.import_module("simulation.orca.prompts.sections.patient")
+    return module, simulation
+
+
+@pytest.mark.asyncio
+async def test_patient_section_requires_context(patient_module):
+    module, _ = patient_module
+    section = module.PatientNameSection()
+
+    with pytest.raises(ValueError) as exc_info:
+        await section.render_instruction()
+
+    assert "Missing required context variable" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_patient_section_renders_from_simulation_object(patient_module):
+    module, simulation = patient_module
+    section = module.PatientNameSection()
+
+    rendered = await section.render_instruction(simulation=simulation)
+
+    assert simulation.sim_patient_full_name in rendered
+
+
+@pytest.mark.asyncio
+async def test_patient_section_resolves_simulation_id(patient_module):
+    module, simulation = patient_module
+    section = module.PatientNameSection()
+
+    rendered = await section.render_instruction(simulation_id=simulation.pk)
+
+    assert simulation.sim_patient_full_name in rendered


### PR DESCRIPTION
## Summary
- fix patient prompt simulation lookup to use provided context values and keep missing-context errors to absent inputs only
- add tests covering missing simulation context and successful rendering from simulation IDs or objects

## Testing
- uv run pytest tests/simworks/test_patient_prompt_section.py *(fails: protobuf dependency download)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f44dff58883338c58a4590f2325f2)