### PR TITLE
Adjust ChatLab content block boundaries

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/index.html
+++ b/SimWorks/chatlab/templates/chatlab/index.html
@@ -41,8 +41,9 @@
         {% include 'chatlab/partials/simulation_history_base.html' %}
     {% endif %}
 
-    {% endblock content %}
 </section>
+
+{% endblock content %}
 
 {% block scripts %}
 {{ block.super }}


### PR DESCRIPTION
## Summary
- ensure the ChatLab index content block wraps the full section
- keep section closing tag inside the content block and confirm block order with scripts remains intact

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59c201cc8333aef201d2783752a2)