### PR TITLE
Improve chat input accessibility for chatlab

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/partials/input_form.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/input_form.html
@@ -7,9 +7,16 @@
         isFeedbackContinuation: {{ feedback_continuation|yesno:'true,false' }},
         }"
 >
-  <button type="button" id="emoji-button" title="Emoji" class="emoji-button hide-small">
+  <button
+          type="button"
+          id="emoji-button"
+          title="Emoji"
+          class="emoji-button hide-small"
+          aria-label="Insert emoji"
+  >
         <span class="iconify chat-icon" data-icon="fa6-regular:face-smile" data-inline="false"></span>
   </button>
+  <label for="chat-message-input" class="sr-only">Message</label>
   <textarea
     x-model="messageText"
     id="chat-message-input"
@@ -23,6 +30,11 @@
                 ? 'Message Stitch to continue feedback conversation'
                 : 'Message'
     "
+    :aria-label="
+        isLocked
+            ? 'Simulation locked — chat is read-only'
+            : 'Message'
+    "
     @input="notifyTyping"
     rows="1"
     style="resize: none"
@@ -31,9 +43,22 @@
     <button
             class="hide-small"
             type="submit"
-            :disabled="isLocked">
+            :disabled="isLocked"
+            :aria-label="isLocked ? 'Send message (disabled while simulation is locked)' : 'Send message'">
       <span
           class="iconify chat-icon mr-4"
+          :class="{ 'color-accent-blue': !isLocked }"
+          data-icon="bi:arrow-up-circle-fill"
+          data-inline="false"
+      ></span>
+    </button>
+    <button
+            class="show-small"
+            type="submit"
+            :disabled="isLocked"
+            :aria-label="isLocked ? 'Send message (disabled while simulation is locked)' : 'Send message'">
+      <span
+          class="iconify chat-icon"
           :class="{ 'color-accent-blue': !isLocked }"
           data-icon="bi:arrow-up-circle-fill"
           data-inline="false"

--- a/SimWorks/static/css/base.css
+++ b/SimWorks/static/css/base.css
@@ -240,6 +240,22 @@ a { color: inherit; }
 .xxxlarge { font-size:48px !important }
 .jumbo { font-size: 64px !important }
 
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.show-small {
+  display: inline-flex !important;
+  align-items: center;
+}
+
 .overlay {
   position: fixed;
   top: 0;
@@ -295,6 +311,7 @@ a { color: inherit; }
 @media only screen and (min-device-width: 768px) {
     .hide-medium, .hide-large { display: none!important }
     .hide-small { display: block!important;}
+    .show-small { display: none!important; }
 }
 
 .section, .code {


### PR DESCRIPTION
## Summary
- add screen-reader-only label and aria labels for chat input controls
- provide accessible send buttons for both small and larger screens while preserving locked messaging
- include utility styles for screen-reader text and small-screen send control visibility

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59d7e38483339ef83f02d667e155)