### PR TITLE
Add labels to simulation search and order forms

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/partials/simulation_history_search.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/simulation_history_search.html
@@ -6,10 +6,15 @@
       hx-push-url="true"
       hx-trigger="submit"
       class="search-form flex flex-col gap-2 bg-white dark:bg-zinc-900 p-4 rounded-md shadow">
-    <input type="text" name="q" placeholder="Search for simulations..." value="{{ search_query }}" autocomplete="off">
-    <label class="flex items-center gap-2">
-        <input type="checkbox" name="search_messages" value="1" {% if search_messages %}checked{% endif %}>
-        Look in simulation messages also
-    </label>
+    <div class="form-group">
+        <label for="simulation-search-input">Search for simulations</label>
+        <input id="simulation-search-input" type="text" name="q" placeholder="Search for simulations..." value="{{ search_query }}" autocomplete="off">
+    </div>
+    <div class="form-group">
+        <label class="flex items-center gap-2 font-normal" for="search-messages-checkbox">
+            <input id="search-messages-checkbox" type="checkbox" name="search_messages" value="1" {% if search_messages %}checked{% endif %}>
+            Look in simulation messages also
+        </label>
+    </div>
     <button class="btn ghost" type="submit">Search</button>
 </form>

--- a/SimWorks/simulation/templates/simulation/partials/order-request-form.html
+++ b/SimWorks/simulation/templates/simulation/partials/order-request-form.html
@@ -2,19 +2,20 @@
 
 <div class="overlay-content" @click.stop>
   <button class="close-button" id="close-order-request-form">✕</button>
-  <div class="lab-order-form">
+    <div class="lab-order-form">
 
-    <!-- Input field and Add button -->
-    <div class="form-group">
-      <input
-        type="text"
-        id="lab-order-input"
-        placeholder="Enter lab order"
-        maxlength="30"
-        class="order-input my-2"
-      />
-      <button type="button" id="stage-order-btn" class="btn sm ghost">Add</button>
-    </div>
+      <!-- Input field and Add button -->
+      <div class="form-group">
+        <label for="lab-order-input">Lab order</label>
+        <input
+          type="text"
+          id="lab-order-input"
+          placeholder="Enter lab order"
+          maxlength="30"
+          class="order-input my-2"
+        />
+        <button type="button" id="stage-order-btn" class="btn sm ghost">Add</button>
+      </div>
 
     <!-- Display orders staged for signature -->
     <ul id="staged-orders-list" class="staged-orders-list">


### PR DESCRIPTION
## Summary
- add labeled inputs to the chat simulation search form for accessibility and consistent styling
- label the lab order entry field in the simulation order request overlay

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59dcf9988333a49eef160a5a7765)