### PR TITLE
Improve invite table responsiveness

### DIFF
--- a/SimWorks/accounts/static/accounts/style.css
+++ b/SimWorks/accounts/static/accounts/style.css
@@ -69,6 +69,35 @@
   margin: 0.25rem 0;
 }
 
+.invite-table-wrapper {
+  overflow-x: auto;
+  padding-top: 0.5rem;
+}
+
+.invite-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--color-text-dark);
+  min-width: 640px;
+}
+
+.invite-table th,
+.invite-table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.invite-table th {
+  background-color: var(--color-bg-alt);
+  font-weight: 700;
+}
+
+.invite-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
 /* Responsive Layouts */
 @media (min-width: 768px) {
   .invite-container,
@@ -93,6 +122,48 @@
 
   .tile-grid {
     grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .invite-table {
+    min-width: unset;
+    display: block;
+    border: none;
+  }
+
+  .invite-table thead {
+    display: none;
+  }
+
+  .invite-table tbody {
+    display: block;
+  }
+
+  .invite-table tr {
+    display: block;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+    background-color: var(--color-bg);
+  }
+
+  .invite-table td {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.35rem 0;
+    border: none;
+    white-space: normal;
+  }
+
+  .invite-table td::before {
+    content: attr(data-label);
+    font-weight: 700;
+    color: var(--color-muted);
+    min-width: 7rem;
+    text-transform: uppercase;
   }
 }
 

--- a/SimWorks/accounts/templates/accounts/partials/invite_single.html
+++ b/SimWorks/accounts/templates/accounts/partials/invite_single.html
@@ -26,42 +26,49 @@
         </div>
     {% endfor %}
 {% else %}
-    <table>
-        <tr>
-            <th>Email</th>
-            <th>Claimed</th>
-            <th>Expired</th>
-            <th>Expiration</th>
-            <th>Invited By</th>
-            <th>Token</th>
-        </tr>
-        {% for invite in invitations %}
-        <tr>
-            <td>{{ invite.email }}</td>
-            <td>{{ invite.is_claimed }}</td>
-            <td>{{ invite.is_expired }}</td>
-            <td>{{ invite.expires_at }}</td>
-            <td>{{ invite.invited_by }}</td>
-            <td><code>{{ invite.token }}</code></td>
-            <td>
-                <div x-data="{ open: false, copied: false }" class="invite-settings">
-                    <button @click="open = !open" class="settings-button">
-                        <span class="iconify" data-icon="mdi:cog-outline"></span>
-                    </button>
-                    <div x-show="open" class="settings-menu" @click.outside="open = false">
-                        <button disabled title="Email integration not yet available">Resend</button>
-                        <a href="{% comment %} TODO {% url 'accounts:recreate_invite' token=invite.token %}{% endcomment %}">Recreate</a>
-                        <button
-                          @click='copyToClipboard("{{ request.scheme }}://{{ request.get_host }}{{ invite.get_absolute_url }}").then(() => { copied = true; open = false; setTimeout(() => copied = false, 1500); })'
-                        >
-                          <span class="iconify" data-icon="solar:copy-line-duotone" data-inline="true"></span>
-                          Copy URL
-                        </button>
-                        <span x-show="copied" x-transition class="copied-tooltip" style="margin-left: 0.5rem; color: green; font-size: 0.85rem;">Copied!</span>
-                    </div>
-                </div>
-            </td>
-        </tr>
-        {% endfor %}
-    </table>
+    <div class="overflow-x-auto px-4 invite-table-wrapper">
+        <table class="invite-table">
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Claimed</th>
+                    <th>Expired</th>
+                    <th>Expiration</th>
+                    <th>Invited By</th>
+                    <th>Token</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for invite in invitations %}
+                <tr>
+                    <td data-label="Email">{{ invite.email }}</td>
+                    <td data-label="Claimed">{{ invite.is_claimed }}</td>
+                    <td data-label="Expired">{{ invite.is_expired }}</td>
+                    <td data-label="Expiration">{{ invite.expires_at }}</td>
+                    <td data-label="Invited By">{{ invite.invited_by }}</td>
+                    <td data-label="Token"><code>{{ invite.token }}</code></td>
+                    <td data-label="Actions">
+                        <div x-data="{ open: false, copied: false }" class="invite-settings">
+                            <button @click="open = !open" class="settings-button">
+                                <span class="iconify" data-icon="mdi:cog-outline"></span>
+                            </button>
+                            <div x-show="open" class="settings-menu" @click.outside="open = false">
+                                <button disabled title="Email integration not yet available">Resend</button>
+                                <a href="{% comment %} TODO {% url 'accounts:recreate_invite' token=invite.token %}{% endcomment %}">Recreate</a>
+                                <button
+                                  @click='copyToClipboard("{{ request.scheme }}://{{ request.get_host }}{{ invite.get_absolute_url }}").then(() => { copied = true; open = false; setTimeout(() => copied = false, 1500); })'
+                                >
+                                  <span class="iconify" data-icon="solar:copy-line-duotone" data-inline="true"></span>
+                                  Copy URL
+                                </button>
+                                <span x-show="copied" x-transition class="copied-tooltip" style="margin-left: 0.5rem; color: green; font-size: 0.85rem;">Copied!</span>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- wrap the invite table in a horizontally scrollable container with padding and an explicit actions header
- add mobile-friendly data labels and stacking styles for invite rows on narrow screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59e33a8c8333a407abb48e9b062d)