### PR TITLE
Serve local Alpine/HTMX assets and align toast audio

### DIFF
--- a/SimWorks/templates/base.html
+++ b/SimWorks/templates/base.html
@@ -11,12 +11,9 @@
     {% endblock style %}
     {% block head-scripts %}
         <script src="https://code.iconify.design/3/3.1.0/iconify.min.js"></script>
-        <!--<script SimWorks="{% static 'js/htmx.min.js' %}" defer></script>-->
-        <!--<script SimWorks="{% static 'js/intersect.min.js'%}" defer></script>--->
-        <!--<script SimWorks="{% static "js/alpine.min.js" %}" defer></script>--->
-        <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-        <script src="https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.x.x/dist/cdn.min.js" defer></script>
-        <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js"></script>
+        <script src="{% static 'js/alpine.min.js' %}" defer></script>
+        <script src="{% static 'js/intersect.min.js' %}" defer></script>
+        <script src="{% static 'js/htmx.min.js' %}"></script>
     {% endblock head-scripts %}
     <meta name="csrf-token" content="{{ csrf_token }}">
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
@@ -72,7 +69,7 @@
                          <button onclick="this.parentElement.remove()">X</button>`;
       container.insertBefore(toast, container.firstChild);
 
-      const sound = document.getElementById("toast-sound");
+      const sound = document.getElementById("alert-sound");
       if (sound) {
         sound.currentTime = 0;
         sound.play().catch(() => {});


### PR DESCRIPTION
## Summary
- load Alpine, its intersect plugin, and HTMX from bundled static assets instead of CDNs
- remove unused commented script tags from the base template
- reuse the existing alert sound for toast playback to avoid missing audio elements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59eba440833397d2ab1acb7e6489)