### PR TITLE
Improve accessibility for chat message list

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/chat.html
+++ b/SimWorks/chatlab/templates/chatlab/chat.html
@@ -23,8 +23,10 @@
     hx-get="{% url 'chatlab:refresh_messages' simulation.id %}"
     hx-trigger="load"
     hx-swap="innerHTML"
+    role="list"
+    aria-live="polite"
   >
-    <div id="message-load-anchor"></div>
+    <div id="message-load-anchor" aria-hidden="true"></div>
     <!-- Messages will be swapped here by HTMX -->
   </div>
 

--- a/SimWorks/chatlab/templates/chatlab/partials/messages.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/messages.html
@@ -2,7 +2,8 @@
 {% for message in messages %}
   <div class="chat-bubble {% if message.sender.username == user.username %}outgoing{% else %}incoming{% endif %}"
        data-message-id="{{ message.id }}"
-        data-has-media="{{ message.has_media }}">
+       data-has-media="{{ message.has_media }}"
+       role="listitem">
     <strong class="sender-name">
       {{ message.display_name|default:message.sender.get_full_name|default:message.sender.username }}
     </strong>
@@ -17,11 +18,12 @@
     {% endif %}
     {{ message.content|linebreaksbr }}
     <div class="timestamp">
-        <span
+        <time
           class="bubble-time"
+          datetime="{{ message.timestamp|date:'c' }}"
           x-data="{ time: new Date('{{ message.timestamp|date:'c' }}').toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) }"
-          x-text="time">
-        </span>
+          x-text="time"
+        >{{ message.timestamp|date:"H:i" }}</time>
         {% if message.sender == user.username %}
         <span class="status-icons" x-data="{ delivered: true, read: false }">
           <span class="iconify status-icon delivered-icon" data-icon="fa6-regular:circle-check" data-inline="false" x-show="delivered"></span>

--- a/SimWorks/chatlab/views.py
+++ b/SimWorks/chatlab/views.py
@@ -152,7 +152,7 @@ def refresh_messages(request, simulation_id):
         "-timestamp"
     )[:5]
     messages = reversed(messages)  # Show oldest at top
-    return render(request, "chatlab/partials/messages.html", {"input": messages})
+    return render(request, "chatlab/partials/messages.html", {"messages": messages})
 
 
 @require_GET
@@ -167,7 +167,7 @@ def load_older_messages(request, simulation_id):
         simulation_id=simulation_id, timestamp__lt=before_message.timestamp
     ).order_by("-timestamp")[:5]
     messages = reversed(messages)
-    return render(request, "chatlab/partials/messages.html", {"input": messages})
+    return render(request, "chatlab/partials/messages.html", {"messages": messages})
 
 
 from django.views.decorators.http import require_POST


### PR DESCRIPTION
## Summary
- set chat message container to act as a polite live region and list for HTMX swaps
- add listitem roles and semantic time elements to rendered chat messages
- align message refresh views with template expectations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59f367848333819a54e8717e4230)