### PR TITLE
Add CSRF handling to simulation order form

### DIFF
--- a/SimWorks/simulation/templates/simulation/partials/order-request-form.html
+++ b/SimWorks/simulation/templates/simulation/partials/order-request-form.html
@@ -25,8 +25,9 @@
       id="sign-orders-form"
       hx-post="{% url 'simulation:sign_orders' simulation.id %}"
       hx-trigger="submit"
-      hx-headers='{"Content-Type": "application/json"}'
+      hx-headers='{"Content-Type": "application/json", "X-CSRFToken": "{{ csrf_token }}"}'
     >
+      {% csrf_token %}
       <button type="submit" id="sign-orders-btn" class="btn sm accent">
         <span>Sign Orders</span>
       </button>


### PR DESCRIPTION
## Summary
- add CSRF token to the simulation sign orders form
- include the CSRF token in htmx headers while keeping JSON content type

## Testing
- not run (template-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59cd0bc08333bec205b384cb0dc8)