### PR TITLE
Add Alpine toast controller for consistent notifications

### DIFF
--- a/SimWorks/templates/partials/dev_warning.html
+++ b/SimWorks/templates/partials/dev_warning.html
@@ -1,7 +1,6 @@
 <div class="fixed top-0 right-0 m-4 space-y-2" id="notifications-container">
     <div
-        x-data="{ show: true }"
-        x-init="if (!'toast-warning warning persistent'.includes('persistent')) { setTimeout(() => show = false, 5000) }"
+        x-data="toastController('SimWorks is still under active development.', 'toast-warning warning persistent')"
         x-show="show"
         x-transition:enter="transition ease-out duration-300 transform"
         x-transition:enter-start="opacity-0 translate-y-2"
@@ -30,6 +29,6 @@
                 Sorry for the inconvenience, and thanks for using the app!
             </p>
         </div>
-        <button @click="show = false" class="dismiss" aria-label="Dismiss">&times;</button>
+        <button @click="dismiss()" class="dismiss" aria-label="Dismiss">&times;</button>
     </div>
 </div>

--- a/SimWorks/templates/partials/notifications.html
+++ b/SimWorks/templates/partials/notifications.html
@@ -1,8 +1,7 @@
 <div class="fixed top-0 right-0 m-4 space-y-2" id="notifications-container">
   {% for message in messages reversed %}
     <div
-      x-data="{ show: true }"
-      x-init="if (!'{{ message.extra_tags }}'.includes('persistent')) { setTimeout(() => show = false, 5000) }"
+      x-data="toastController('{{ message|escapejs }}', '{{ message.extra_tags }}')"
       x-show="show"
       x-transition:enter="transition ease-out duration-300 transform"
       x-transition:enter-start="opacity-0 translate-y-2"
@@ -14,7 +13,7 @@
       aria-live="assertive"
       class="toast flex items-center justify-between {{ message.extra_tags }}">
       <span>{{ message }}</span>
-      <button @click="show = false" class="dismiss" aria-label="Dismiss">&times;</button>
+      <button @click="dismiss()" class="dismiss" aria-label="Dismiss">&times;</button>
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- add a reusable Alpine toast controller that manages visibility, timers, and persistence cleanup
- apply the shared controller to both notification partials to unify dismissal and persistent behavior
- centralize persistence helpers for WebSocket and Alpine-driven notifications

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c08ea308333872f3180622e36e2)