### PR TITLE
Refactor chat form Alpine state handling

### DIFF
--- a/SimWorks/chatlab/static/chatlab/js/chat.js
+++ b/SimWorks/chatlab/static/chatlab/js/chat.js
@@ -1,3 +1,65 @@
+function chatFormState({ isLocked, isFeedbackContinuation }) {
+    return {
+        isLocked,
+        isFeedbackContinuation,
+        messageText: '',
+        showEmojiPicker: false,
+        init() {
+            this.syncFromRoot();
+        },
+        toggleEmojiPicker() {
+            this.showEmojiPicker = !this.showEmojiPicker;
+        },
+        handleInput() {
+            this.autoResize();
+            this.notifyTyping();
+        },
+        notifyTyping() {
+            this.$root?.notifyTyping();
+        },
+        autoResize() {
+            if (this.$refs.messageInput) {
+                this.$refs.messageInput.style.height = 'auto';
+                this.$refs.messageInput.style.height = `${this.$refs.messageInput.scrollHeight}px`;
+            }
+        },
+        send() {
+            if (this.isLocked) return;
+
+            if (this.$root) {
+                this.$root.messageText = this.messageText;
+                this.$root.sendMessage();
+                this.messageText = this.$root.messageText;
+            }
+
+            this.showEmojiPicker = false;
+            this.autoResize();
+        },
+        sendFromMobile() {
+            this.send();
+        },
+        syncFromRoot() {
+            if (this.$root && typeof this.$root.messageText === 'string') {
+                this.messageText = this.$root.messageText;
+            }
+        },
+        placeholderText() {
+            if (this.isLocked) return 'Simulation locked — chat is read-only';
+            if (this.isFeedbackContinuation) return 'Message Stitch to continue feedback conversation';
+            return 'Message';
+        },
+        messageAriaLabel() {
+            return this.isLocked ? 'Simulation locked — chat is read-only' : 'Message';
+        },
+        sendAriaLabel() {
+            return this.isLocked ? 'Send message (disabled while simulation is locked)' : 'Send message';
+        },
+        emojiAriaLabel() {
+            return this.showEmojiPicker ? 'Hide emoji picker' : 'Insert emoji';
+        }
+    };
+}
+
 function ChatManager(simulation_id, currentUser, initialChecksum) {
     return {
         currentUser,
@@ -56,23 +118,6 @@ function ChatManager(simulation_id, currentUser, initialChecksum) {
                     this.loadOlderMessages();
                 }
             });
-
-            // Enhanced message input behavior: auto-resize and send on Enter, Shift+Enter for newline
-            if (this.messageInput) {
-                // Auto-resize on input
-                this.messageInput.addEventListener('input', () => {
-                    this.messageInput.style.height = 'auto';
-                    this.messageInput.style.height = this.messageInput.scrollHeight + 'px';
-                });
-
-                // Send on Enter, allow Shift+Enter for newline
-                this.messageInput.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault();
-                        this.sendMessage();
-                    }
-                });
-            }
         },
         notifyTyping() {
             const now = Date.now();
@@ -484,6 +529,7 @@ function ChatManager(simulation_id, currentUser, initialChecksum) {
 }
 
 window.ChatManager = ChatManager;
+window.chatFormState = chatFormState;
 
 function sidebarGesture() {
   return {

--- a/SimWorks/chatlab/templates/chatlab/partials/input_form.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/input_form.html
@@ -1,18 +1,20 @@
 {% load static %}
 
 <form id="chat-form"
-    @submit.prevent="sendMessage"
-    x-data="{
+    @submit.prevent="send"
+    x-data="chatFormState({
         isLocked: {{ simulation_locked|yesno:'true,false' }},
         isFeedbackContinuation: {{ feedback_continuation|yesno:'true,false' }},
-        }"
+    })"
 >
   <button
           type="button"
           id="emoji-button"
           title="Emoji"
           class="emoji-button hide-small"
-          aria-label="Insert emoji"
+          :aria-label="emojiAriaLabel()"
+          :aria-pressed="showEmojiPicker"
+          @click.prevent="toggleEmojiPicker"
   >
         <span class="iconify chat-icon" data-icon="fa6-regular:face-smile" data-inline="false"></span>
   </button>
@@ -21,21 +23,11 @@
     x-model="messageText"
     id="chat-message-input"
     x-ref="messageInput"
-    x-on:input="$refs.messageInput.style.height = 'auto'; $refs.messageInput.style.height = $refs.messageInput.scrollHeight + 'px'"
+    @input="handleInput"
+    @keydown.enter.exact.prevent="send"
     :disabled="isLocked"
-    :placeholder="
-        isLocked
-            ? 'Simulation locked — chat is read-only'
-            : isFeedbackContinuation
-                ? 'Message Stitch to continue feedback conversation'
-                : 'Message'
-    "
-    :aria-label="
-        isLocked
-            ? 'Simulation locked — chat is read-only'
-            : 'Message'
-    "
-    @input="notifyTyping"
+    :placeholder="placeholderText()"
+    :aria-label="messageAriaLabel()"
     rows="1"
     style="resize: none"
     autofocus
@@ -44,7 +36,9 @@
             class="hide-small"
             type="submit"
             :disabled="isLocked"
-            :aria-label="isLocked ? 'Send message (disabled while simulation is locked)' : 'Send message'">
+            :aria-label="sendAriaLabel()"
+            @click.prevent="send"
+    >
       <span
           class="iconify chat-icon mr-4"
           :class="{ 'color-accent-blue': !isLocked }"
@@ -56,7 +50,9 @@
             class="show-small"
             type="submit"
             :disabled="isLocked"
-            :aria-label="isLocked ? 'Send message (disabled while simulation is locked)' : 'Send message'">
+            :aria-label="sendAriaLabel()"
+            @click.prevent="sendFromMobile"
+    >
       <span
           class="iconify chat-icon"
           :class="{ 'color-accent-blue': !isLocked }"


### PR DESCRIPTION
## Summary
- move chat input form state into a dedicated Alpine component with message, lock, feedback, and emoji toggle handling
- bind chat input placeholders and send button aria labels through component helpers and add a mobile-friendly send action
- simplify ChatManager initialization by delegating input sizing and submit behavior to the form component

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c0996a483339e846d45459dbd04)