### PR TITLE
Improve user menu accessibility and focus handling

### DIFF
--- a/SimWorks/templates/partials/header.html
+++ b/SimWorks/templates/partials/header.html
@@ -1,6 +1,31 @@
 {% load static %}
 
-<header id="header" x-data="{ openMenu: false }">
+<header id="header" x-data="{
+        openMenu: false,
+        toggleMenu() { this.openMenu = !this.openMenu },
+        closeMenu() { this.openMenu = false },
+        trapFocus(event) {
+            if (!this.openMenu || event.key !== 'Tab') return;
+
+            const dropdown = this.$refs.userMenuDropdown;
+            const focusable = dropdown ? dropdown.querySelectorAll('a, button, [tabindex]:not([tabindex="-1"])') : [];
+            if (!focusable.length) return;
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        }
+    }" x-init="$watch('openMenu', value => { if (value) { $nextTick(() => {
+            const firstFocusable = $refs.userMenuDropdown?.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+            (firstFocusable || $refs.userMenuDropdown)?.focus();
+        }) } })" @keydown.escape.window="closeMenu">
     <!-- Header Navigation Bar  -->
     <div id="navBar" class="top bar flex">
         <a href="{% url 'home' %}" class="bar-item button">
@@ -19,30 +44,30 @@
             <span class="iconify fit" data-icon="mdi:register-outline" data-inline="true"></span> Register!</a>
         {% endif %}
         <!-- User Menu Toggle -->
-        <button id="user-menu-toggle" @click="openMenu = ! openMenu" @click.outside="openMenu = false" class="bar-item button hover-black">
+        <button id="user-menu-toggle" type="button" @click="toggleMenu" :aria-expanded="openMenu.toString()" aria-controls="user-menu-dropdown" class="bar-item button hover-black">
             <span class="iconify" data-icon="fa-solid:bars" data-inline="false"></span>
         </button>
     </div>
     <!-- User Menu -->
-    <div id="user-menu" class="bar-item top right">
+    <div id="user-menu" class="bar-item top right" @click.outside="closeMenu">
         <!-- User Menu Dropdown -->
-        <div id="user-menu-dropdown" x-cloak x-show.important="openMenu">
+        <div id="user-menu-dropdown" x-ref="userMenuDropdown" tabindex="-1" x-cloak x-show.important="openMenu" @keydown.escape.stop.prevent="closeMenu" @keydown.tab="trapFocus($event)">
             <!-- Small Screen Navigation -->
             <div id="small-screen-nav" class="hide-medium hide-large">
-                <a href="{% url 'chatlab:index' %}" class="sidebar-item button" @click="openMenu = false"> ChatLab</a>
+                <a href="{% url 'chatlab:index' %}" class="sidebar-item button" @click="closeMenu"> ChatLab</a>
             </div>
             <!-- User Account Navigation -->
             <div id="user-account-nav">
                 {% if user.is_authenticated %}
-                    <a href="{% url 'accounts:profile' %}" class="sidebar-item button my-4" @click="openMenu = false">Profile</a>
+                    <a href="{% url 'accounts:profile' %}" class="sidebar-item button my-4" @click="closeMenu">Profile</a>
                     <!--<a href="{% url 'accounts:logout' %}" class="sidebar-item button" @click="openMenu = false">Logout</a>-->
                     <form action="{% url 'accounts:logout' %}" method="post" style="display: inline;">
                         {% csrf_token %}
-                        <button type="submit" class="sidebar-item button my-4 accent" @click="open-menu = false">Logout</button>
+                        <button type="submit" class="sidebar-item button my-4 accent" @click="closeMenu">Logout</button>
                     </form>
                 {% else %}
-                    <a href="{% url 'accounts:login' %}" class="sidebar-item button acct hide-large hide-medium" @click="openMenu = false">Login</a>
-                    <a href="{% url 'accounts:register' %}" class="sidebar-item button acct hide-large hide-medium" @click="openMenu = false">Registration</a>
+                    <a href="{% url 'accounts:login' %}" class="sidebar-item button acct hide-large hide-medium" @click="closeMenu">Login</a>
+                    <a href="{% url 'accounts:register' %}" class="sidebar-item button acct hide-large hide-medium" @click="closeMenu">Registration</a>
                 {% endif %}
                 <div class="sidebar-item" x-data="themeToggle()" x-init="init()">
                     <button @click="toggle()" class="theme-toggle" title="Toggle theme">


### PR DESCRIPTION
## Summary
- bind the user menu toggle state to aria-expanded while keeping Alpine-managed controls
- trap focus in the dropdown, closing it on escape or outside interaction
- ensure mobile navigation and auth links close the menu when activated

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c0a7e5c83338edcabdd23f9772d)