### PR TITLE
Improve simulation tool panel Alpine state handling

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/simulation.html
+++ b/SimWorks/chatlab/templates/chatlab/simulation.html
@@ -172,5 +172,20 @@
             }
         }
     }
+
+    function toolPanelState(toolName, simulationId) {
+        const storageKey = `toolOpen_${toolName}_${simulationId}`;
+        const storedValue = localStorage.getItem(storageKey);
+        return {
+            toolName,
+            panelId: `${toolName}_tool`,
+            storageKey,
+            isOpen: storedValue === null ? true : JSON.parse(storedValue),
+            toggle() {
+                this.isOpen = !this.isOpen;
+                localStorage.setItem(this.storageKey, JSON.stringify(this.isOpen));
+            },
+        }
+    }
     </script>
 {% endblock scripts %}

--- a/SimWorks/simulation/templates/simulation/partials/tools/_wrapper.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_wrapper.html
@@ -1,51 +1,63 @@
 {# templates/simulation/partials/tools/sidebar_wrapper.html #}
 {% load core_tags %}
 <!-- Simulation Tool: {{ tool.name }} -->
-<div id="{{ tool.name|lower }}-tool-header"
-     class="tool-header px-4"
-     @click="toggle('{{ tool.name|lower }}')">
-    <h3 class="medium">
-        <span class="iconify" data-icon="material-symbols:menu-open-rounded" data-inline="true"></span>
-        {{ tool.display_name }}
-    </h3>
+<div class="tool-panel" x-data="toolPanelState('{{ tool.name|lower }}', {{ simulation.id }})">
+    <div id="{{ tool.name|lower }}-tool-header"
+         class="tool-header px-4"
+         @click="toggle()"
+         @keydown.enter.prevent="toggle()"
+         @keydown.space.prevent="toggle()"
+         role="button"
+         tabindex="0"
+         :aria-expanded="isOpen"
+         :aria-controls="panelId">
+        <h3 class="medium">
+            <span class="iconify" data-icon="material-symbols:menu-open-rounded" data-inline="true"></span>
+            {{ tool.display_name }}
+        </h3>
 
-    {% if tool.name|lower == "simulation_feedback" %}
-    <form method="POST"
-          action="{% url 'chatlab:run_simulation' simulation.id %}?feedback_continue_conversation=true"
-          x-show="
-            {{ simulation_locked|default_if_none:False|yesno:'true,false' }}
-            && !{{ feedback_continuation|default_if_none:False|yesno:'true,false' }}
-          ">
-        {% csrf_token %}
-        <button type="submit" class="btn xs accent" style="font-size: 80%">
-            Continue conversation with Stitch
-        </button>
-    </form>
-    {% endif %}
-
-    <button @click.stop="toggle('{{ tool.name|lower }}')"
-            class="btn pri sm hide-small my-4"
-            x-text="isOpen('{{ tool.name|lower }}') ? 'Hide' : 'Show'">
-    </button>
-</div>
-
-<div id="{{ tool.name|lower }}_tool"
-     data-checksum="{{ tool.checksum }}"
-     x-show="isOpen('{{ tool.name|lower }}')"
-     x-transition:enter="transition ease-out duration-300"
-     x-transition:enter-start="opacity-0 -translate-y-2"
-     x-transition:enter-end="opacity-100 translate-y-0"
-     x-transition:leave="transition ease-in duration-200"
-     x-transition:leave-start="opacity-100 translate-y-0"
-     x-transition:leave-end="opacity-0 -translate-y-2">
-
-    {% with custom_partial='simulation/partials/tools/_'|add:tool.name|add:'.html' %}
-        {% if custom_partial|template_exists %}
-            {% include custom_partial with tool=tool %}
-        {% elif tool.is_generic %}
-            {% include 'simulation/partials/tools/_generic.html' with tool=tool %}
-        {% else %}
-            {% include 'simulation/partials/tools/_fallback.html' with tool=tool %}
+        {% if tool.name|lower == "simulation_feedback" %}
+        <form method="POST"
+              action="{% url 'chatlab:run_simulation' simulation.id %}?feedback_continue_conversation=true"
+              @click.stop
+              x-show="
+                {{ simulation_locked|default_if_none:False|yesno:'true,false' }}
+                && !{{ feedback_continuation|default_if_none:False|yesno:'true,false' }}
+              ">
+            {% csrf_token %}
+            <button type="submit" class="btn xs accent" style="font-size: 80%">
+                Continue conversation with Stitch
+            </button>
+        </form>
         {% endif %}
-    {% endwith %}
+
+        <button type="button"
+                @click.stop="toggle()"
+                class="btn pri sm hide-small my-4"
+                :aria-expanded="isOpen"
+                :aria-controls="panelId"
+                x-text="isOpen ? 'Hide' : 'Show'">
+        </button>
+    </div>
+
+    <div id="{{ tool.name|lower }}_tool"
+         data-checksum="{{ tool.checksum }}"
+         x-show="isOpen"
+         x-transition:enter="transition ease-out duration-300"
+         x-transition:enter-start="opacity-0 -translate-y-2"
+         x-transition:enter-end="opacity-100 translate-y-0"
+         x-transition:leave="transition ease-in duration-200"
+         x-transition:leave-start="opacity-100 translate-y-0"
+         x-transition:leave-end="opacity-0 -translate-y-2">
+
+        {% with custom_partial='simulation/partials/tools/_'|add:tool.name|add:'.html' %}
+            {% if custom_partial|template_exists %}
+                {% include custom_partial with tool=tool %}
+            {% elif tool.is_generic %}
+                {% include 'simulation/partials/tools/_generic.html' with tool=tool %}
+            {% else %}
+                {% include 'simulation/partials/tools/_fallback.html' with tool=tool %}
+            {% endif %}
+        {% endwith %}
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- add a per-tool Alpine component that persists open/closed state and exposes aria attributes
- update simulation tool header toggle controls to avoid nested form conflicts and support keyboard interaction
- keep tool content panels bound to the new component state while retaining existing transitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c0c1cc48333a43e3c983869c984)