### PR TITLE
Improve ChatLab modifier tray accessibility

### DIFF
--- a/SimWorks/chatlab/static/chatlab/css/style.css
+++ b/SimWorks/chatlab/static/chatlab/css/style.css
@@ -90,6 +90,20 @@ body {
   z-index: 10;
   max-height: 300px;
   overflow-y: auto;
+  transform-origin: top right;
+  transition: opacity 150ms ease, transform 150ms ease;
+}
+
+.modifier-group {
+  margin-bottom: 1rem;
+}
+
+.modifier-legend {
+  font-weight: bold;
+}
+
+.modifier-option {
+  display: block;
 }
 /* Layout utilities */
 .flex-column {

--- a/SimWorks/chatlab/templates/chatlab/index.html
+++ b/SimWorks/chatlab/templates/chatlab/index.html
@@ -7,27 +7,54 @@
         <h1>Welcome to ChatLab</h1>
         {% if user.is_authenticated %}
             <form method="get" action="{% url 'chatlab:create_simulation' %}" class="start-form">
-                <div class="dropdown-wrapper" x-data="modifierSelector()" x-init="fetchModifierGroups()" @click.away="modifierTrayOpen = false">
+                <div
+                    class="dropdown-wrapper"
+                    x-data="modifierSelector()"
+                    x-init="init()"
+                    x-id="['modifier-tray']"
+                    @click.away="closeTray()"
+                    @keydown.escape.window="closeTray()"
+                >
                     <div class="button-group">
                         <button type="submit" class="btn pri sm">Begin New Simulation</button>
-                        <button type="button" class="btn sm" @click="modifierTrayOpen = !modifierTrayOpen">▼</button>
+                        <button
+                            type="button"
+                            class="btn sm"
+                            @click="toggleTray()"
+                            :aria-expanded="modifierTrayOpen.toString()"
+                            :aria-controls="$id('modifier-tray')"
+                        >
+                            ▼
+                        </button>
                     </div>
 
-                    <template x-if="modifierTrayOpen">
-                        <div class="modifier-tray">
-                            <template x-for="group in modifierGroups" :key="group.group">
-                                <fieldset x-show="group.group !== 'Feedback'" style="margin-bottom: 1em;">
-                                    <legend x-text="group.group" style="font-weight: bold;"></legend>
-                                    <template x-for="mod in group.modifiers" :key="mod.key">
-                                        <label style="display: block;">
-                                            <input type="checkbox" :value="mod.key" x-model="selected">
-                                            <span x-text="mod.description"></span>
-                                        </label>
-                                    </template>
-                                </fieldset>
-                            </template>
-                        </div>
-                    </template>
+                    <div
+                        x-ref="modifierTray"
+                        :id="$id('modifier-tray')"
+                        class="modifier-tray"
+                        x-show="modifierTrayOpen"
+                        x-trap.noscroll="modifierTrayOpen"
+                        x-transition.opacity.scale.origin.top.right
+                        x-cloak
+                        role="group"
+                        tabindex="-1"
+                        @keydown.arrow-down.prevent="focusNext()"
+                        @keydown.arrow-up.prevent="focusPrevious()"
+                        @keydown.home.prevent="focusFirst()"
+                        @keydown.end.prevent="focusLast()"
+                    >
+                        <template x-for="group in modifierGroups" :key="group.group">
+                            <fieldset x-show="group.group !== 'Feedback'" class="modifier-group">
+                                <legend x-text="group.group" class="modifier-legend"></legend>
+                                <template x-for="mod in group.modifiers" :key="mod.key">
+                                    <label class="modifier-option">
+                                        <input type="checkbox" :value="mod.key" x-model="selected">
+                                        <span x-text="mod.description"></span>
+                                    </label>
+                                </template>
+                            </fieldset>
+                        </template>
+                    </div>
 
                     <template x-for="mod in selected" :key="mod">
                         <input type="hidden" name="modifier" :value="mod">
@@ -53,6 +80,56 @@ function modifierSelector() {
         modifierTrayOpen: false,
         selected: [],
         modifierGroups: [],
+        init() {
+            this.fetchModifierGroups();
+            this.$watch('modifierTrayOpen', (isOpen) => {
+                if (isOpen) {
+                    this.$nextTick(() => {
+                        if (!this.focusFirst()) {
+                            this.$refs.modifierTray?.focus();
+                        }
+                    });
+                }
+            });
+        },
+        toggleTray() {
+            this.modifierTrayOpen = !this.modifierTrayOpen;
+        },
+        closeTray() {
+            this.modifierTrayOpen = false;
+        },
+        focusableOptions() {
+            return Array.from(this.$refs.modifierTray?.querySelectorAll('input[type="checkbox"]') || []);
+        },
+        focusFirst() {
+            return this.setFocusIndex(0);
+        },
+        focusLast() {
+            return this.setFocusIndex(this.focusableOptions().length - 1);
+        },
+        focusNext() {
+            const options = this.focusableOptions();
+            if (!options.length) return false;
+            const currentIndex = options.indexOf(document.activeElement);
+            const targetIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length;
+            return this.setFocusIndex(targetIndex);
+        },
+        focusPrevious() {
+            const options = this.focusableOptions();
+            if (!options.length) return false;
+            const currentIndex = options.indexOf(document.activeElement);
+            const targetIndex = currentIndex <= 0 ? options.length - 1 : currentIndex - 1;
+            return this.setFocusIndex(targetIndex);
+        },
+        setFocusIndex(index) {
+            const options = this.focusableOptions();
+            const option = options[index];
+            if (option) {
+                option.focus();
+                return true;
+            }
+            return false;
+        },
         async fetchModifierGroups() {
             try {
                 const response = await fetch("{% url 'graphql' %}", {
@@ -78,7 +155,6 @@ function modifierSelector() {
                 });
                 const result = await response.json();
                 this.modifierGroups = result?.data?.modifierGroups || [];
-                console.log("Fetched modifierGroups:", this.modifierGroups)
             } catch (error) {
                 console.error("Failed to load modifier groups", error);
             }


### PR DESCRIPTION
## Summary
- refactor the ChatLab modifier selector to manage open/close behavior with Alpine, including focus trapping, keyboard navigation, and outside-click handling
- move inline modifier styles into reusable CSS classes and add aria-expanded plus consistent tray transitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c0d30388333aaec2db761b2fb08)