### PR TITLE
Improve chat layout spacing and responsiveness

### DIFF
--- a/SimWorks/chatlab/static/chatlab/css/chat.css
+++ b/SimWorks/chatlab/static/chatlab/css/chat.css
@@ -9,19 +9,26 @@
 .chat-container {
   display: flex;
   flex-direction: column;
-  padding-bottom: 4.5rem; /* Leave space for fixed chat input */
-  height: calc(100vh - 8vh - 42px); /* footer collapses */
-  overflow: auto;
+  gap: clamp(0.75rem, 1.5vw, 1rem);
+  padding: clamp(0.75rem, 2vw, 1.25rem) clamp(0.5rem, 2.5vw, 1.5rem) clamp(5.5rem, 12vw, 7rem);
+  min-height: calc(100vh - 6rem);
+  height: auto;
+  overflow-y: auto;
+  font-size: clamp(0.95rem, 1.5vw, 1.05rem);
 }
 
 /* Make sure input scroll and fill container */
-#chat-messages {
+#chat-messages,
+.message-list {
   flex: 1 1 auto;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  padding: 1rem;
-  gap: 0.5rem;
+  gap: clamp(0.5rem, 1vw, 0.75rem);
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  min-height: clamp(55vh, 70vh, 80vh);
+  scroll-padding-bottom: 5rem;
 }
 
 /* Chat bubbles */
@@ -133,7 +140,7 @@
     width: 100%;
     z-index: 999;
     box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.1);
-    padding: 0.5rem 0.5rem;
+    padding: 0.75rem 0.75rem calc(0.75rem + env(safe-area-inset-bottom));
   }
 
 #chat-message-input {


### PR DESCRIPTION
## Summary
- add responsive padding and typography scales for the chat container and message list
- ensure the chat area can scroll vertically with a sensible minimum height and bottom spacing
- adjust chat form padding to keep the input reachable on small screens and respect safe areas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c0f090c8333bc6e1fba77e4f506)