### PR TITLE
Improve responsive layout for patient results table

### DIFF
--- a/SimWorks/chatlab/static/chatlab/css/sim-metadata.css
+++ b/SimWorks/chatlab/static/chatlab/css/sim-metadata.css
@@ -64,15 +64,33 @@
 }
 
 table.sim-metadata {
+  width: 100%;
+  border-collapse: collapse;
   text-align: left;
-  th, td {
-    text-align: left;
-    padding: 0 10px;
-    border-bottom: 1px solid var(--color-border);
-  }
-  th {
-    border-bottom-width: 2px;
-  }
+}
+
+table.sim-metadata th,
+table.sim-metadata td {
+  text-align: left;
+  padding: 0.35rem 0.65rem;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: top;
+  white-space: normal;
+  word-break: break-word;
+}
+
+table.sim-metadata th {
+  border-bottom-width: 2px;
+}
+
+.sim-metadata-table-wrapper {
+  margin: 0.5rem auto;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .staged-item {
@@ -126,4 +144,46 @@ table.sim-metadata {
 ────────────────────────────────────────────────── */
 @media (min-width: 64em) {
     /* 1024px; landscape tablet and larger */
+}
+
+@media (max-width: 48em) {
+  .sim-metadata-table-wrapper {
+    padding: 0.5rem;
+  }
+
+  table.sim-metadata th,
+  table.sim-metadata td {
+    padding: 0.35rem 0.5rem;
+  }
+
+  table.sim-metadata thead {
+    display: none;
+  }
+
+  table.sim-metadata tbody tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.25rem 0.75rem;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  table.sim-metadata tbody tr:last-child {
+    border-bottom: none;
+  }
+
+  table.sim-metadata td {
+    display: block;
+    padding: 0;
+  }
+
+  table.sim-metadata td::before {
+    content: attr(data-label);
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: var(--color-muted);
+    margin-bottom: 0.15rem;
+  }
 }

--- a/SimWorks/simulation/templates/simulation/partials/tools/_patient_results.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_patient_results.html
@@ -12,35 +12,37 @@
     </button>
 
     {% if tool.data %}
-        <table class="sim-metadata small">
-            <thead>
-                <tr>
-                    <th>Panel Name</th>
-                    <th>Order Name</th>
-                    <th>Value</th>
-                    <th>Unit</th>
-                    <th>Reference Range</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                {% for result in tool.data %}
+        <div class="sim-metadata-table-wrapper">
+            <table class="sim-metadata small">
+                <thead>
                     <tr>
-                        <td>{{ result.panel_name }}</td>
-                        <td>{{ result.result_name }}</td>
-                        <td>
-                            {{ result.value }}
-                            {% if result.flag|upper != "NORMAL" %}
-                                <span style="color: red">!! </span>
-                            {% endif %}
-                        </td>
-                        <td>{{ result.unit }}</td>
-                        <td>({{ result.reference_range_low }} - {{ result.reference_range_high }})</td>
+                        <th>Panel Name</th>
+                        <th>Order Name</th>
+                        <th>Value</th>
+                        <th>Unit</th>
+                        <th>Reference Range</th>
                     </tr>
-                {% endfor %}
-            </tbody>
+                </thead>
 
-        </table>
+                <tbody>
+                    {% for result in tool.data %}
+                        <tr>
+                            <td data-label="Panel Name">{{ result.panel_name }}</td>
+                            <td data-label="Order Name">{{ result.result_name }}</td>
+                            <td data-label="Value">
+                                {{ result.value }}
+                                {% if result.flag|upper != "NORMAL" %}
+                                    <span style="color: red">!! </span>
+                                {% endif %}
+                            </td>
+                            <td data-label="Unit">{{ result.unit }}</td>
+                            <td data-label="Reference Range">({{ result.reference_range_low }} - {{ result.reference_range_high }})</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+
+            </table>
+        </div>
     {% else %}
       <div class="sim-metadata-empty">No results available yet.</div>
     {% endif %}


### PR DESCRIPTION
## Summary
- wrap the patient results table in a padded, horizontally scrollable container
- add responsive table styling to reduce spacing and wrap content on smaller screens
- include data labels for stacked cells so results remain readable without horizontal scrolling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c1047388333a12e77ac315e2553)