### PR TITLE
Make invitation filters responsive on small screens

### DIFF
--- a/SimWorks/accounts/static/accounts/style.css
+++ b/SimWorks/accounts/static/accounts/style.css
@@ -18,8 +18,29 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+.invite-controls {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+  align-items: start;
+  margin: 1rem 0 1.5rem;
+}
+
+.invite-filter-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr;
+}
+
 .invite-actions {
-  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.invite-actions .btn {
+  width: 100%;
 }
 
 /* Heading styling for forms */
@@ -103,12 +124,32 @@
 }
 
 /* Responsive Layouts */
+@media (min-width: 640px) {
+  .invite-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+  }
+
+  .invite-actions .btn {
+    width: auto;
+  }
+
+  .invite-filter-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
 @media (min-width: 768px) {
   .invite-container,
   .login-container,
   .signup-container,
   .profile-container {
     max-width: 600px;
+  }
+
+  .invite-controls {
+    grid-template-columns: 2fr 1fr;
   }
 
   .tile-grid {
@@ -130,6 +171,10 @@
 }
 
 @media (max-width: 640px) {
+  .tile-grid {
+    grid-template-columns: 1fr;
+  }
+
   .invite-table {
     min-width: unset;
     display: block;

--- a/SimWorks/accounts/templates/accounts/invite_list.html
+++ b/SimWorks/accounts/templates/accounts/invite_list.html
@@ -43,34 +43,33 @@
 }" x-init="init()">
     <h1>All Invitations</h1>
 
-    <div class="invite-actions mb-16">
-        <button class="btn pri sm" @click="viewMode = viewMode === 'list' ? 'grid' : 'list'">
-            Switch to <span x-text="viewMode === 'list' ? 'Tile' : 'List'"></span> View
-        </button>
-    </div>
+    <div class="invite-controls mb-16">
+        <div class="invite-filter-grid">
+            <select class="filter-input" x-model="claimedFilter">
+                <option value="">All</option>
+                <option value="true">Claimed</option>
+                <option value="false">Unclaimed</option>
+            </select>
+            <select class="filter-input" x-model="expiredFilter">
+                <option value="">All</option>
+                <option value="true">Expired</option>
+                <option value="false">Active</option>
+            </select>
+            <select class="filter-input" multiple x-model="invitedByFilter">
+                <template x-for="inviter in {{ inviter_choices|safe }}">
+                    <option :value="inviter" x-text="inviter"></option>
+                </template>
+            </select>
+        </div>
 
-    <div class="filter-bar filter-scroll">
-        <select class="filter-input" x-model="claimedFilter">
-            <option value="">All</option>
-            <option value="true">Claimed</option>
-            <option value="false">Unclaimed</option>
-        </select>
-        <select class="filter-input" x-model="expiredFilter">
-            <option value="">All</option>
-            <option value="true">Expired</option>
-            <option value="false">Active</option>
-        </select>
-        <select class="filter-input" multiple x-model="invitedByFilter">
-            <template x-for="inviter in {{ inviter_choices|safe }}">
-                <option :value="inviter" x-text="inviter"></option>
-            </template>
-        </select>
-    </div>
-
-    <div class="mt-16 mx-auto invite-actions">
-        <button class="btn ghost sm" @click="clearFilters()">
-            Clear Filters
-        </button>
+        <div class="invite-actions">
+            <button class="btn pri sm" @click="viewMode = viewMode === 'list' ? 'grid' : 'list'">
+                Switch to <span x-text="viewMode === 'list' ? 'Tile' : 'List'"></span> View
+            </button>
+            <button class="btn ghost sm" @click="clearFilters()">
+                Clear Filters
+            </button>
+        </div>
     </div>
 
     <div

--- a/SimWorks/accounts/templates/accounts/partials/invite_single.html
+++ b/SimWorks/accounts/templates/accounts/partials/invite_single.html
@@ -1,30 +1,32 @@
 {% if view_mode == 'grid' %}
-    {% for invite in invitations %}
-        <div class="tile-card" style="--tile-index: {{ forloop.counter0 }}">
-            <p><strong>Email:</strong> {{ invite.email }}</p>
-            <p><strong>Claimed:</strong> {{ invite.is_claimed }}</p>
-            <p><strong>Expired:</strong> {{ invite.is_expired }}</p>
-            <p><strong>Expires:</strong> {{ invite.expires_at }}</p>
-            <p><strong>Invited By:</strong> {{ invite.invited_by }}</p>
-            <div x-data="{ open: false, copied: false }" class="invite-settings">
-                <button @click="open = !open" class="btn">
-                    <span class="iconify" data-icon="mdi:cog-outline"></span>
-                </button>
-                <div x-show="open" class="settings-menu" @click.outside="open = false">
-                    <button disabled title="Email integration not yet available">Resend Invitation</button>
-                    <a href="{% comment %} TODO {% url 'accounts:recreate_invite' token=invite.token %}{% endcomment %}">Recreate Invitation</a>
-                    <button
-                        @click="$clipboard(`{{ invite.link }}`)"
-                        @clipboard.copied="copied = true; open = false; setTimeout(() => copied = false, 1500)"
-                    >
-                        <span class="iconify" data-icon="solar:copy-line-duotone" data-inline="true"></span>
-                        Copy Invite URL
+    <div class="tile-grid">
+        {% for invite in invitations %}
+            <div class="tile-card" style="--tile-index: {{ forloop.counter0 }}">
+                <p><strong>Email:</strong> {{ invite.email }}</p>
+                <p><strong>Claimed:</strong> {{ invite.is_claimed }}</p>
+                <p><strong>Expired:</strong> {{ invite.is_expired }}</p>
+                <p><strong>Expires:</strong> {{ invite.expires_at }}</p>
+                <p><strong>Invited By:</strong> {{ invite.invited_by }}</p>
+                <div x-data="{ open: false, copied: false }" class="invite-settings">
+                    <button @click="open = !open" class="btn">
+                        <span class="iconify" data-icon="mdi:cog-outline"></span>
                     </button>
-                    <span x-show="copied" x-transition class="copied-tooltip" style="margin-left: 0.5rem; color: green; font-size: 0.85rem;">Copied!</span>
+                    <div x-show="open" class="settings-menu" @click.outside="open = false">
+                        <button disabled title="Email integration not yet available">Resend Invitation</button>
+                        <a href="{% comment %} TODO {% url 'accounts:recreate_invite' token=invite.token %}{% endcomment %}">Recreate Invitation</a>
+                        <button
+                            @click="$clipboard(`{{ invite.link }}`)"
+                            @clipboard.copied="copied = true; open = false; setTimeout(() => copied = false, 1500)"
+                        >
+                            <span class="iconify" data-icon="solar:copy-line-duotone" data-inline="true"></span>
+                            Copy Invite URL
+                        </button>
+                        <span x-show="copied" x-transition class="copied-tooltip">Copied!</span>
+                    </div>
                 </div>
             </div>
-        </div>
-    {% endfor %}
+        {% endfor %}
+    </div>
 {% else %}
     <div class="overflow-x-auto px-4 invite-table-wrapper">
         <table class="invite-table">
@@ -62,7 +64,7 @@
                                   <span class="iconify" data-icon="solar:copy-line-duotone" data-inline="true"></span>
                                   Copy URL
                                 </button>
-                                <span x-show="copied" x-transition class="copied-tooltip" style="margin-left: 0.5rem; color: green; font-size: 0.85rem;">Copied!</span>
+                                <span x-show="copied" x-transition class="copied-tooltip">Copied!</span>
                             </div>
                         </div>
                     </td>


### PR DESCRIPTION
## Summary
- stack invite filters and actions into a responsive grid so controls collapse cleanly on small screens
- wrap the invitation grid view in a tile container and move inline tooltip styling into CSS classes
- add breakpoint-based styling to keep buttons, filters, and grid tiles from overflowing on narrow viewports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c1333d08333a9fcc4bd2c401ce4)