### PR TITLE
Improve simulation mobile sidebar overlay layout

### DIFF
--- a/SimWorks/chatlab/static/chatlab/css/simulation.css
+++ b/SimWorks/chatlab/static/chatlab/css/simulation.css
@@ -39,9 +39,12 @@
 .sim-main {
     /* height: calc(100vh - var(--footer-height, 5vh)); */
     height: 100%;
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    min-height: 0;
+    touch-action: pan-y;
 }
 
 .sim-sidebar {
@@ -55,9 +58,10 @@
     background-color: var(--color-bg-alt);
     border-right: 1px solid var(--color-border);
     transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
     z-index: 100;
     overflow-y: auto;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
 .sim-sidebar.visible {
@@ -71,6 +75,13 @@
 
 .sim-sidebar-wrapper {
     width: 100%;
+}
+
+.sim-chat {
+    flex: 1;
+    min-width: 320px;
+    min-height: 0;
+    transition: filter 0.25s ease;
 }
 .tool-header {
     display: flex;
@@ -156,8 +167,10 @@
         border-bottom: 1px solid var(--color-border);
     }
     .sim-main {
+        display: grid;
         grid-template-columns: 1fr 1fr;
         grid-template-rows: 1fr;
+        min-height: 0;
     }
     .sim-sidebar {
         position: relative;

--- a/SimWorks/chatlab/static/chatlab/js/chat.js
+++ b/SimWorks/chatlab/static/chatlab/js/chat.js
@@ -489,8 +489,8 @@ function sidebarGesture() {
   return {
     shouldPulse:  localStorage.getItem('seenSidebarTray') !== 'true',
     sidebarOpen: false,
-    startX: 0,
-    endX: 0,
+    startX: null,
+    endX: null,
     swipeThreshold: 40,
 
     openSidebar() {
@@ -505,12 +505,21 @@ function sidebarGesture() {
     },
 
     startTouch(event) {
+      if (event.target.closest('#chat-form')) {
+        this.startX = null;
+        this.endX = null;
+        return;
+      }
+
       this.startX = event.changedTouches[0].screenX;
+      this.endX = this.startX;
     },
     moveTouch(event) {
+      if (this.startX === null) return;
       this.endX = event.changedTouches[0].screenX;
     },
     endTouch() {
+      if (this.startX === null) return;
       const diff = this.endX - this.startX;
 
     if (!this.sidebarOpen && this.startX > 10 && this.startX < 60 && diff > this.swipeThreshold) {
@@ -518,6 +527,9 @@ function sidebarGesture() {
       } else if (this.sidebarOpen && diff < -this.swipeThreshold) {
         this.closeSidebar();
       }
+
+      this.startX = null;
+      this.endX = null;
     },
 
     maybeClose(event) {


### PR DESCRIPTION
## Summary
- adjust the simulation layout so the sidebar overlays the chat on small screens while keeping the chat at a readable minimum width
- smooth out sidebar and chat transitions for the sliding overlay behavior
- guard touch gestures so swipes near the chat input do not hide the composer when toggling the sidebar

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c14624883338b14d7de70d94378)