### PR TITLE
Add reusable form field partial for Django templates

### DIFF
--- a/SimWorks/accounts/templates/accounts/invite_new.html
+++ b/SimWorks/accounts/templates/accounts/invite_new.html
@@ -18,7 +18,9 @@
           hx-swap="innerHTML transition:true"
           hx-indicator="#invite-loading">
         {% csrf_token %}
-        {{ form.as_p }}
+        {% for field in form %}
+            {% include "partials/forms/_field.html" with field=field %}
+        {% endfor %}
         <button class="btn pri m-auto" type="submit" hx-indicator="#invite-loading">
             Create Invite Token
         </button>

--- a/SimWorks/accounts/templates/accounts/signup.html
+++ b/SimWorks/accounts/templates/accounts/signup.html
@@ -18,26 +18,14 @@
     {% endif %}
     <form method="post" action="{% url 'accounts:register' %}">
         {% csrf_token %}
-        <div class="form-group">
-            <label for="{{ form.invitation_token.id_for_label }}">Invitation Token:</label>
-            {% if token %}
-                <input type="text" name="{{ form.invitation_token.name }}" id="{{ form.invitation_token.id_for_label }}" value="{{ token }}" readonly>
-            {% else %}
-                {{ form.invitation_token }}
-            {% endif %}
-        </div>
+        {% if token %}
+            {% include "partials/forms/_field.html" with field=form.invitation_token widget="<input type='text' name='"|add:form.invitation_token.name|add:"' id='"|add:form.invitation_token.id_for_label|add:"' value='"|add:token|add:"' readonly>" %}
+        {% else %}
+            {% include "partials/forms/_field.html" with field=form.invitation_token %}
+        {% endif %}
         {% for field in form %}
             {% if field.name != "invitation_token" %}
-                <p>
-                    {{ field.label_tag }}<br>
-                    {{ field }}
-                    {% if field.errors %}
-                        <span class="error">{{ field.errors }}</span>
-                    {% endif %}
-                    {% if field.help_text %}
-                        <small>{{ field.help_text }}</small>
-                    {% endif %}
-                </p>
+                {% include "partials/forms/_field.html" with field=field %}
             {% endif %}
         {% endfor %}
         <button class="btn pri" type="submit">Sign Up</button>

--- a/SimWorks/accounts/templates/registration/login.html
+++ b/SimWorks/accounts/templates/registration/login.html
@@ -20,14 +20,8 @@
         <form method="post" action="{% url 'accounts:login' %}">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
-            <div class="form-group">
-                <label for="id_username">Username:</label>
-                {{ form.username }}
-            </div>
-            <div class="form-group">
-                <label for="id_password">Password:</label>
-                {{ form.password }}
-            </div>
+            {% include "partials/forms/_field.html" with field=form.username %}
+            {% include "partials/forms/_field.html" with field=form.password %}
             <button type="submit" class="btn pri">Login</button>
         </form>
         {# <p>Don't have an accounts? <a href="{% url 'signup' %}">Sign up</a></p> #}

--- a/SimWorks/chatlab/templates/chatlab/partials/simulation_history_search.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/simulation_history_search.html
@@ -6,15 +6,11 @@
       hx-push-url="true"
       hx-trigger="submit"
       class="search-form flex flex-col gap-2 bg-white dark:bg-zinc-900 p-4 rounded-md shadow">
-    <div class="form-group">
-        <label for="simulation-search-input">Search for simulations</label>
-        <input id="simulation-search-input" type="text" name="q" placeholder="Search for simulations..." value="{{ search_query }}" autocomplete="off">
-    </div>
-    <div class="form-group">
-        <label class="flex items-center gap-2 font-normal" for="search-messages-checkbox">
-            <input id="search-messages-checkbox" type="checkbox" name="search_messages" value="1" {% if search_messages %}checked{% endif %}>
-            Look in simulation messages also
-        </label>
-    </div>
+    {% with search_input="<input id='simulation-search-input' type='text' name='q' placeholder='Search for simulations...' value='"|add:search_query|add:"' autocomplete='off'>" %}
+        {% include "partials/forms/_field.html" with label="Search for simulations" id="simulation-search-input" widget=search_input %}
+    {% endwith %}
+    {% with checkbox_input="<input id='search-messages-checkbox' type='checkbox' name='search_messages' value='1' "|add:("checked" if search_messages else "")|add:" >" %}
+        {% include "partials/forms/_field.html" with label="Look in simulation messages also" widget=checkbox_input label_after_widget=True %}
+    {% endwith %}
     <button class="btn ghost" type="submit">Search</button>
 </form>

--- a/SimWorks/templates/partials/forms/_field.html
+++ b/SimWorks/templates/partials/forms/_field.html
@@ -1,0 +1,55 @@
+{# Reusable form field renderer for consistent spacing and accessibility #}
+<div class="form-field {% if field and field.errors %}has-error{% endif %}">
+    {% if field %}
+        {% if field.field.widget.input_type == "checkbox" %}
+            <label class="form-label inline" for="{{ field.id_for_label }}">
+                {{ field }}
+                <span>{{ field.label }}</span>
+            </label>
+        {% else %}
+            <label class="form-label" for="{{ field.id_for_label }}">
+                {{ field.label }}
+                {% if field.field.required %}<span class="required">*</span>{% endif %}
+            </label>
+            <div class="form-widget">
+                {{ widget|default:field|safe }}
+            </div>
+        {% endif %}
+        {% if field.help_text %}
+            <p class="form-help">{{ field.help_text }}</p>
+        {% endif %}
+        {% if field.errors %}
+            <ul class="form-errors">
+                {% for error in field.errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% else %}
+        {% if label %}
+            <label class="form-label {% if label_after_widget %}inline{% endif %}" {% if id %}for="{{ id }}"{% endif %}>
+                {% if label_after_widget %}
+                    {{ widget|safe }}
+                    <span>{{ label }}</span>
+                {% else %}
+                    {{ label }}
+                {% endif %}
+            </label>
+        {% endif %}
+        {% if not label_after_widget %}
+            <div class="form-widget">
+                {{ widget|safe }}
+            </div>
+        {% endif %}
+        {% if help_text %}
+            <p class="form-help">{{ help_text }}</p>
+        {% endif %}
+        {% if errors %}
+            <ul class="form-errors">
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add a reusable form field partial to render labels, widgets, help text, and errors consistently
- apply the shared field partial across login, signup, invite, and simulation search forms

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c22fb04833389006472c3e2fe35)