### PR TITLE
Refactor chat message rendering into reusable partial

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/partials/_message.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/_message.html
@@ -1,0 +1,36 @@
+{% comment %} Render a single chat message bubble {% endcomment %}
+<div
+  class="chat-bubble {% if message.sender.username == user.username %}outgoing{% else %}incoming{% endif %}"
+  data-message-id="{{ message.id }}"
+  data-has-media="{{ message.has_media }}"
+  role="listitem"
+  aria-label="{{ message.display_name|default:message.sender.get_full_name|default:message.sender.username }}"
+>
+  <strong class="sender-name">
+    {{ message.display_name|default:message.sender.get_full_name|default:message.sender.username }}
+  </strong>
+  {% if message.has_media %}
+    <div class="media-container" role="list">
+      {% for media in message.media.all %}
+        <div id="media_{{ media.uuid }}" class="media-wrapper" role="listitem">
+          <img src="{{ media.thumbnail.url }}" alt="{{ media.description }}" class="media-image">
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {{ message.content|linebreaksbr }}
+  <div class="timestamp">
+    <time
+      class="bubble-time"
+      datetime="{{ message.timestamp|date:'c' }}"
+      x-data="{ time: new Date('{{ message.timestamp|date:'c' }}').toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) }"
+      x-text="time"
+    >{{ message.timestamp|date:"H:i" }}</time>
+    {% if message.sender == user.username %}
+    <span class="status-icons" x-data="{ delivered: true, read: false }">
+      <span class="iconify status-icon delivered-icon" data-icon="fa6-regular:circle-check" data-inline="false" x-show="delivered"></span>
+      <span class="iconify status-icon read-icon" data-icon="fa6-regular:circle-check" data-inline="false" x-show="read"></span>
+    </span>
+    {% endif %}
+  </div>
+</div>

--- a/SimWorks/chatlab/templates/chatlab/partials/messages.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/messages.html
@@ -1,35 +1,4 @@
 {% comment %} Renders a list of chat input {% endcomment %}
 {% for message in messages %}
-  <div class="chat-bubble {% if message.sender.username == user.username %}outgoing{% else %}incoming{% endif %}"
-       data-message-id="{{ message.id }}"
-       data-has-media="{{ message.has_media }}"
-       role="listitem">
-    <strong class="sender-name">
-      {{ message.display_name|default:message.sender.get_full_name|default:message.sender.username }}
-    </strong>
-    {% if message.has_media %}
-      <div class="media-container">
-        {% for media in message.media.all %}
-          <div id="media_{{ media.uuid }}" class="media-wrapper">
-            <img src="{{ media.thumbnail.url }}" alt="{{ media.description }}" class="media-image">
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
-    {{ message.content|linebreaksbr }}
-    <div class="timestamp">
-        <time
-          class="bubble-time"
-          datetime="{{ message.timestamp|date:'c' }}"
-          x-data="{ time: new Date('{{ message.timestamp|date:'c' }}').toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) }"
-          x-text="time"
-        >{{ message.timestamp|date:"H:i" }}</time>
-        {% if message.sender == user.username %}
-        <span class="status-icons" x-data="{ delivered: true, read: false }">
-          <span class="iconify status-icon delivered-icon" data-icon="fa6-regular:circle-check" data-inline="false" x-show="delivered"></span>
-          <span class="iconify status-icon read-icon" data-icon="fa6-regular:circle-check" data-inline="false" x-show="read"></span>
-        </span>
-        {% endif %}
-    </div>
-  </div>
+  {% include "chatlab/partials/_message.html" %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- add a dedicated `_message` partial to render chat bubbles with media and list semantics
- update the `messages` partial to loop through the shared fragment for consistent formatting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c28e35083339f41940779956f4e)