### PR TITLE
Add reusable empty state partial for Django UI

### DIFF
--- a/SimWorks/chatlab/templates/chatlab/partials/simulation_history_base.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/simulation_history_base.html
@@ -12,8 +12,13 @@
         {% include 'chatlab/partials/simulation_history_search.html' %}
         {% include 'chatlab/partials/simulation_history_list.html' %}
     {% else %}
-        <p class="no-simulations-msg">You haven't started any simulations... <a
-                href="{% url 'chatlab:create_simulation' %}" class="btn sm">start one now</a> and let the chaos begin 🩺💥</p>
+        {% url 'chatlab:create_simulation' as create_simulation_url %}
+        {% include 'partials/_empty_state.html' with
+            title="No simulations yet"
+            body="Start your first scenario to see it show up here."
+            cta_url=create_simulation_url
+            cta_text="Start a simulation"
+            cta_class="btn sm pri" %}
     {% endif %}
 
 </section>

--- a/SimWorks/chatlab/templates/chatlab/partials/simulation_history_list.html
+++ b/SimWorks/chatlab/templates/chatlab/partials/simulation_history_list.html
@@ -23,7 +23,15 @@
                 – {% if sim.is_complete %}✅ Complete{% else %}🟢 In Progress{% endif %}
             </li>
         {% empty %}
-            <li>No simulations yet.</li>
+            <li class="list-style-none">
+                {% url 'chatlab:create_simulation' as create_simulation_url %}
+                {% include 'partials/_empty_state.html' with
+                    title="No simulations yet"
+                    body="Start your first scenario to see it show up here."
+                    cta_url=create_simulation_url
+                    cta_text="Start a simulation"
+                    cta_class="btn sm pri" %}
+            </li>
         {% endfor %}
     </ul>
     <div class="pagination">
@@ -44,4 +52,5 @@
         {% endif %}
     </div>
 </div>
+
 

--- a/SimWorks/simulation/templates/simulation/partials/tools/_fallback.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_fallback.html
@@ -1,4 +1,5 @@
 {# templates/simulation/partials/_fallback.html #}
-<div class="sim-metadata-empty">
-  Tool not available yet. Please check back later.
-</div>
+{% include 'partials/_empty_state.html' with
+    title="Tool not available"
+    body="This tool is still loading. Please check back soon."
+    extra_classes="sim-metadata-empty" %}

--- a/SimWorks/simulation/templates/simulation/partials/tools/_generic.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_generic.html
@@ -6,5 +6,8 @@
     {% endfor %}
   </ul>
 {% else %}
-  <div class="sim-metadata-empty">No data available yet.</div>
+  {% include 'partials/_empty_state.html' with
+      title="No data available"
+      body="We will display details here once they're ready."
+      extra_classes="sim-metadata-empty" %}
 {% endif %}

--- a/SimWorks/simulation/templates/simulation/partials/tools/_patient_history.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_patient_history.html
@@ -6,5 +6,8 @@
     {% endfor %}
   </ul>
 {% else %}
-  <div class="sim-metadata-empty">No known medical history available.</div>
+  {% include 'partials/_empty_state.html' with
+      title="No medical history yet"
+      body="We'll surface known history here once we have it."
+      extra_classes="sim-metadata-empty" %}
 {% endif %}

--- a/SimWorks/simulation/templates/simulation/partials/tools/_patient_results.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_patient_results.html
@@ -42,7 +42,10 @@
 
         </table>
     {% else %}
-      <div class="sim-metadata-empty">No results available yet.</div>
+      {% include 'partials/_empty_state.html' with
+          title="No results yet"
+          body="Order labs or imaging to see results populate here."
+          extra_classes="sim-metadata-empty" %}
     {% endif %}
 
     <!-- Order Request Form -->

--- a/SimWorks/simulation/templates/simulation/partials/tools/_simulation_feedback.html
+++ b/SimWorks/simulation/templates/simulation/partials/tools/_simulation_feedback.html
@@ -19,5 +19,8 @@
     {% endfor %}
   </ul>
 {% else %}
-  <div class="sim-metadata-empty">No feedback available yet.</div>
+  {% include 'partials/_empty_state.html' with
+      title="No feedback yet"
+      body="Feedback will appear here after your conversation progresses."
+      extra_classes="sim-metadata-empty" %}
 {% endif %}

--- a/SimWorks/static/css/base.css
+++ b/SimWorks/static/css/base.css
@@ -467,6 +467,37 @@ a { color: inherit; }
 }
 
 /* ───────────────────────────────────────────────
+   Shared Styles: Empty States
+────────────────────────────────────────────────── */
+
+.empty-state {
+  background-color: var(--color-bg-alt);
+  border: 1px dashed var(--color-border);
+  border-radius: 0.75rem;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  text-align: center;
+}
+
+.empty-state__title {
+  margin: 0;
+}
+
+.empty-state__body {
+  color: var(--color-muted);
+  margin: 0.35rem 0 0;
+}
+
+.empty-state__cta {
+  margin-top: 0.75rem;
+}
+
+.list-style-none {
+  list-style: none;
+  padding-left: 0;
+}
+
+/* ───────────────────────────────────────────────
    Shared Styles: Error Messages
 ────────────────────────────────────────────────── */
 

--- a/SimWorks/templates/partials/_empty_state.html
+++ b/SimWorks/templates/partials/_empty_state.html
@@ -1,0 +1,13 @@
+{# Reusable empty state component #}
+<div class="empty-state {% if extra_classes %}{{ extra_classes }}{% endif %}">
+  <h3 class="empty-state__title">{{ title }}</h3>
+  <p class="empty-state__body">{{ body }}</p>
+  {% if cta_url and cta_text %}
+    <div class="empty-state__cta">
+      <a href="{{ cta_url }}" class="{{ cta_class|default:'btn sm accent' }}">{{ cta_text }}</a>
+    </div>
+  {% elif cta_content %}
+    <div class="empty-state__cta">{{ cta_content }}</div>
+  {% endif %}
+</div>
+


### PR DESCRIPTION
## Summary
- add a reusable empty state partial with optional call-to-action support
- replace inline empty messages in simulation history and tool panels to standardize the experience
- introduce shared styling utilities for the new empty state component

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5c2e30d88333b0b286807502b94d)