### PR TITLE
Add env resolution test for orchestrai client utils

### DIFF
--- a/packages/orchestrai/src/orchestrai/client/utils.py
+++ b/packages/orchestrai/src/orchestrai/client/utils.py
@@ -1,6 +1,8 @@
 # orchestrai/client/utils.py
 from __future__ import annotations
 
+import os
+
 from orchestrai.components.providerkit.provider import ProviderConfig
 from orchestrai.client.schemas import OrcaClientRegistration
 

--- a/packages/orchestrai/tests/test_client_utils.py
+++ b/packages/orchestrai/tests/test_client_utils.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+
+from orchestrai.client.utils import _resolve_from_env
+from orchestrai.components.providerkit.provider import ProviderConfig
+
+
+def test_resolve_from_env_returns_value(monkeypatch):
+    env_key = "ORCHESTRAI_TEST_API_KEY"
+    env_value = "super-secret-value"
+    monkeypatch.setenv(env_key, env_value)
+
+    client = SimpleNamespace(api_key_env=env_key)
+    provider = ProviderConfig(alias="alias", backend="backend", api_key_env="OTHER_ENV")
+
+    assert _resolve_from_env(client, provider) == env_value


### PR DESCRIPTION
## Summary
- import the os module for environment lookups in the client utils
- add a unit test covering _resolve_from_env when an environment variable is set

## Testing
- uv run pytest packages/orchestrai *(fails: unable to download opentelemetry-proto dependency due to network tunnel error)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694075ca18688333a44caade5d8ffad8)