### PR TITLE
Add package initializers for orchestrai subpackages

### DIFF
--- a/packages/orchestrai/src/orchestrai/conf/__init__.py
+++ b/packages/orchestrai/src/orchestrai/conf/__init__.py
@@ -1,0 +1,6 @@
+"""Configuration helpers for OrchestrAI."""
+
+from .defaults import DEFAULTS
+from .settings import Settings
+
+__all__ = ["DEFAULTS", "Settings"]

--- a/packages/orchestrai/src/orchestrai/fixups/__init__.py
+++ b/packages/orchestrai/src/orchestrai/fixups/__init__.py
@@ -1,0 +1,5 @@
+"""Framework fixups for OrchestrAI integrations."""
+
+from .base import BaseFixup
+
+__all__ = ["BaseFixup"]

--- a/packages/orchestrai/src/orchestrai/loaders/__init__.py
+++ b/packages/orchestrai/src/orchestrai/loaders/__init__.py
@@ -1,0 +1,6 @@
+"""Loader implementations for OrchestrAI."""
+
+from .base import BaseLoader
+from .default import DefaultLoader
+
+__all__ = ["BaseLoader", "DefaultLoader"]


### PR DESCRIPTION
## Summary
- add minimal __init__.py modules for orchestrai conf, loaders, and fixups packages
- expose primary classes via __all__ for easier package-level imports

## Testing
- uv run pytest packages/orchestrai *(fails: hatchling could not be fetched from PyPI in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ab7b08e0833395d856b752dd5b4a)