### PR TITLE
Refine client settings flow

### DIFF
--- a/packages/orchestrai/README.md
+++ b/packages/orchestrai/README.md
@@ -39,6 +39,25 @@ with app.as_current():
 
 `start()` (or `run()`) is a convenience wrapper that performs discovery, finalization, prints the jumping-orca welcome banner once, and summarizes registered components.
 
+## Settings flow
+
+`Settings` is the authoritative configuration mapping. The `OrchestrAI` constructor loads defaults from `orchestrai.settings` and applies overrides from `ORCHESTRAI_CONFIG_MODULE` automatically:
+
+```python
+from orchestrai.conf.settings import Settings
+
+settings = Settings()
+settings.update_from_envvar()  # optional when you want to mirror the app's boot logic
+```
+
+Client-facing helpers accept the typed `ClientSettings` model from `orchestrai.client.settings_loader`. Use `load_client_settings` to convert an already-built `Settings` instance; the legacy `load_orca_settings` shim remains for compatibility but emits a deprecation warning:
+
+```python
+from orchestrai.client.settings_loader import ClientSettings, load_client_settings
+
+client_settings: ClientSettings = load_client_settings(settings)
+```
+
 ## Lifecycle overview
 
 1. **configure** – apply settings from mappings, objects, or environment variables.

--- a/packages/orchestrai/docs/full_documentation.md
+++ b/packages/orchestrai/docs/full_documentation.md
@@ -42,6 +42,27 @@ Each method is idempotent and avoids network calls; nothing heavy happens during
 
 Unknown keys are stored but unused by the core, letting extensions consume their own configuration without conflicts.
 
+## Settings flow
+
+`Settings` (`orchestrai.conf.settings.Settings`) is the authoritative configuration mapping. The `OrchestrAI` constructor instantiates it, applies overrides from `orchestrai.settings`, and then layers the optional `ORCHESTRAI_CONFIG_MODULE` module:
+
+```python
+from orchestrai.conf.settings import Settings
+
+settings = Settings()
+settings.update_from_envvar()  # mirrors the default app bootstrap
+```
+
+Helpers that need typed client/provider configuration use `ClientSettings` from `orchestrai.client.settings_loader`. Convert an existing `Settings` instance instead of rebuilding defaults:
+
+```python
+from orchestrai.client.settings_loader import ClientSettings, load_client_settings
+
+client_settings: ClientSettings = load_client_settings(settings)
+```
+
+The legacy `load_orca_settings` function remains as a shim and emits a deprecation warning; new code should import `ClientSettings` and `load_client_settings` directly.
+
 ## Registries
 
 Registries are simple, thread-safe mappings with three phases:

--- a/packages/orchestrai/src/orchestrai/app.py
+++ b/packages/orchestrai/src/orchestrai/app.py
@@ -44,7 +44,7 @@ from .loaders.base import BaseLoader
 from .registry.base import BaseRegistry
 from .registry.simple import AppRegistry, ServiceRunnerRegistry
 from .client.factory import build_orca_client
-from .client.settings_loader import load_orca_settings
+from .client.settings_loader import load_client_settings
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +233,7 @@ class OrchestrAI:
             name = client_conf.get("name") or "default"
             definition = dict(client_conf)
             definition.setdefault("name", name)
-            settings = load_orca_settings(self.conf.as_dict())
+            settings = load_client_settings(self.conf)
             client = build_orca_client(settings, name)
             self.clients.register(name, client)
             self._default_client = name

--- a/packages/orchestrai/src/orchestrai/client/factory.py
+++ b/packages/orchestrai/src/orchestrai/client/factory.py
@@ -20,7 +20,7 @@ from .resolve import (
 )
 from .schemas import OrcaClientConfig, OrcaClientRegistration
 from .utils import effective_provider_config
-from .settings_loader import OrcaSettings, load_orca_settings
+from .settings_loader import ClientSettings, load_client_settings
 from ..components.providerkit.conf_models import (
     ProvidersSettings,
     ProviderSettingsEntry,
@@ -72,7 +72,7 @@ def _ensure_provider_backend_loaded(backend_identity: str) -> None:
 
 
 def _build_single_client(
-        core: OrcaSettings,
+        core: ClientSettings,
         client_alias: str,
         *,
         make_default: bool | None = None,
@@ -130,7 +130,7 @@ logger = logging.getLogger(__name__)
 # The "default" client alias is autoconfigured if not explicitly declared.
 # It assumes settings are already validated for single vs POD mode by the config layer.
 def _build_client_from_settings(
-        core: OrcaSettings,
+        core: ClientSettings,
         client_alias: str,
 ) -> tuple[ProviderConfig, OrcaClientRegistration, OrcaClientConfig]:
     """
@@ -211,20 +211,20 @@ def _build_client_from_settings(
 
 
 def build_orca_client(
-        core: OrcaSettings,
+        core: ClientSettings,
         client_alias: str,
         *,
         make_default: bool | None = None,
         replace: bool = True,
 ):
     """
-    Build and register a single Orca client from OrcaSettings.
+    Build and register a single Orca client from ClientSettings.
 
     This is the low-level factory that bootstrap should call in a loop.
     It does not perform any alias enumeration or mode detection.
 
     Args:
-        core: Loaded OrcaSettings instance.
+        core: Loaded ClientSettings instance.
         client_alias: The client alias to build (e.g. "default").
         make_default: Optional override for whether this client should be
             registered as the default. If None, uses the value from the
@@ -283,10 +283,10 @@ def get_client(name: str | None = None):
     Resolution:
       1) If `name` is provided and a client by that alias already exists in the registry,
          return it.
-      2) Otherwise, build a client from OrcaSettings (PROVIDERS/CLIENTS) and register it.
-      3) If `name` is None, use OrcaSettings.DEFAULT_CLIENT.
+      2) Otherwise, build a client from ClientSettings (PROVIDERS/CLIENTS) and register it.
+      3) If `name` is None, use ClientSettings.DEFAULT_CLIENT.
     """
-    core = load_orca_settings()
+    core = load_client_settings()
 
     client_alias = name or getattr(core, "DEFAULT_CLIENT", "default")
 
@@ -317,7 +317,7 @@ def get_orca_client(
             * the provider wiring resolved from PROVIDERS/CLIENTS.
         This per-call client is NOT registered in the global client registry.
     """
-    core = load_orca_settings()
+    core = load_client_settings()
     if getattr(core, "MODE", "single") == "single":
         single_client = core.CLIENT
 

--- a/packages/orchestrai/src/orchestrai/client/resolve.py
+++ b/packages/orchestrai/src/orchestrai/client/resolve.py
@@ -7,7 +7,7 @@ from ..components.providerkit.conf_models import (
     ProvidersSettings,
     ProviderSettingsEntry,
 )
-from .settings_loader import OrcaSettings
+from .settings_loader import ClientSettings
 
 
 def get_client_entry_or_default(
@@ -31,7 +31,7 @@ def get_client_entry_or_default(
 
 
 def resolve_provider_alias(
-    core: OrcaSettings,
+    core: ClientSettings,
     providers_settings: ProvidersSettings,
     centry: OrcaClientEntry | None,
     client_alias: str,
@@ -82,7 +82,7 @@ def resolve_provider_alias(
 
 
 def resolve_profile_alias(
-    core: OrcaSettings,
+    core: ClientSettings,
     pentry: ProviderSettingsEntry,
     centry: OrcaClientEntry | None,
     provider_alias: str,
@@ -123,7 +123,7 @@ def resolve_profile_alias(
 
 
 def resolve_api_key(
-    core: OrcaSettings,
+    core: ClientSettings,
     pentry: ProviderSettingsEntry,
     centry: OrcaClientEntry | None,
     provider_alias: str,
@@ -207,7 +207,7 @@ def resolve_client_behavior(
 
 
 def resolve_client_flags(
-    core: OrcaSettings,
+    core: ClientSettings,
     clients_settings: OrcaClientsSettings,
     client_alias: str,
     centry: OrcaClientEntry | None,

--- a/packages/orchestrai/src/orchestrai/client/settings_loader.py
+++ b/packages/orchestrai/src/orchestrai/client/settings_loader.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
+from collections.abc import Mapping
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from ..conf.settings import Settings
@@ -9,7 +13,7 @@ from ..components.providerkit.conf_models import ProvidersSettings
 from .conf_models import OrcaClientsSettings
 
 
-class OrcaSettings(BaseModel):
+class ClientSettings(BaseModel):
     """Structured settings used by the client factory helpers."""
 
     model_config = ConfigDict(extra="ignore")
@@ -24,24 +28,51 @@ class OrcaSettings(BaseModel):
     DEFAULT_PROVIDER_API_KEY_ALIAS: str | None = None
 
     @classmethod
-    def from_mapping(cls, mapping: dict | None = None) -> "OrcaSettings":
+    def from_mapping(cls, mapping: Mapping[str, Any] | None = None) -> "ClientSettings":
         """Construct settings from an untyped mapping of config values."""
 
-        mapping = mapping or {}
+        mapping = dict(mapping or {})
         return cls(**mapping)
 
+    @classmethod
+    def from_settings(cls, settings: Settings) -> "ClientSettings":
+        """Construct settings from a fully prepared ``Settings`` instance."""
 
-def load_orca_settings(mapping: dict | None = None) -> OrcaSettings:
-    """Load and normalize Orca settings using the modern settings layer."""
+        return cls.from_mapping(settings.as_dict())
+
+
+def _coerce_settings(source: Settings | Mapping[str, Any] | None) -> Settings:
+    if isinstance(source, Settings):
+        return source
 
     base = Settings()
     base.update_from_object("orchestrai.settings")
     base.update_from_envvar("ORCHESTRAI_CONFIG_MODULE")
 
-    if mapping:
-        base.update_from_mapping(mapping)
+    if source:
+        base.update_from_mapping(source)
 
-    return OrcaSettings.from_mapping(base.as_dict())
+    return base
 
 
-__all__ = ["load_orca_settings", "OrcaSettings"]
+def load_client_settings(source: Settings | Mapping[str, Any] | None = None) -> ClientSettings:
+    """Normalize client settings, favoring a pre-built ``Settings`` instance."""
+
+    prepared = _coerce_settings(source)
+    return ClientSettings.from_settings(prepared)
+
+
+def load_orca_settings(mapping: Mapping[str, Any] | None = None) -> ClientSettings:
+    """Compatibility shim for the legacy OrcaSettings loader."""
+
+    warnings.warn(
+        "load_orca_settings is deprecated; use load_client_settings with a Settings instance instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return load_client_settings(mapping)
+
+
+OrcaSettings = ClientSettings
+
+__all__ = ["load_client_settings", "ClientSettings", "load_orca_settings", "OrcaSettings"]

--- a/tests/orchestrai/test_service_resolution.py
+++ b/tests/orchestrai/test_service_resolution.py
@@ -4,7 +4,7 @@ import pytest
 
 from orchestrai import OrchestrAI
 from orchestrai.client.registry import clear_clients
-from orchestrai.client.settings_loader import OrcaSettings
+from orchestrai.client.settings_loader import ClientSettings
 from orchestrai.components.services.exceptions import ServiceConfigError
 from orchestrai.components.services.service import BaseService
 from orchestrai.decorators import service
@@ -63,8 +63,8 @@ def test_service_resolution_error_points_to_single_mode(monkeypatch):
 
     clear_clients()
     monkeypatch.setattr(
-        "orchestrai.client.factory.load_orca_settings",
-        lambda mapping=None: OrcaSettings.from_mapping({"MODE": "single", "CLIENT": None}),
+        "orchestrai.client.factory.load_client_settings",
+        lambda mapping=None: ClientSettings.from_mapping({"MODE": "single", "CLIENT": None}),
     )
 
     svc = DummyService()

--- a/tests/orchestrai/test_single_client_factory.py
+++ b/tests/orchestrai/test_single_client_factory.py
@@ -2,7 +2,7 @@ import pytest
 
 from orchestrai.client.factory import build_orca_client
 from orchestrai.client.registry import clear_clients, list_clients
-from orchestrai.client.settings_loader import OrcaSettings
+from orchestrai.client.settings_loader import ClientSettings
 
 
 @pytest.fixture(autouse=True)
@@ -13,7 +13,7 @@ def _reset_clients():
 
 
 def test_single_client_builds_without_providers():
-    core = OrcaSettings.from_mapping(
+    core = ClientSettings.from_mapping(
         {
             "MODE": "single",
             "CLIENT": {
@@ -34,7 +34,7 @@ def test_single_client_builds_without_providers():
 
 
 def test_single_client_uses_model_defaults_when_behavior_missing():
-    core = OrcaSettings.from_mapping(
+    core = ClientSettings.from_mapping(
         {
             "MODE": "single",
             "CLIENT": {
@@ -53,7 +53,7 @@ def test_single_client_uses_model_defaults_when_behavior_missing():
 
 
 def test_multi_mode_without_providers_hints_single_mode():
-    core = OrcaSettings.from_mapping(
+    core = ClientSettings.from_mapping(
         {
             "MODE": "multi",
             "PROVIDERS": {},


### PR DESCRIPTION
## Summary
- replace OrcaSettings with the ClientSettings API and add a deprecated shim for load_orca_settings
- update app and client helpers to consume the new settings loader and typed settings
- document the authoritative Settings/ClientSettings flow in the README and full guide

## Testing
- uv run pytest packages/orchestrai *(fails: unable to download django==6.0 in the sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ac871f008333b410ab90ba90dee5)