### PR TITLE
Add discovery defaults and glob-aware loader resolution

### DIFF
--- a/packages/orchestrai/docs/full_documentation.md
+++ b/packages/orchestrai/docs/full_documentation.md
@@ -36,7 +36,10 @@ Each method is idempotent and avoids network calls; nothing heavy happens during
 - `CLIENT` – name of the default client to expose via `app.client`.
 - `CLIENTS` – mapping of client definitions.
 - `PROVIDERS` – mapping of provider definitions.
-- `DISCOVERY_PATHS` – iterable of dotted module paths to import during discovery.
+- `DISCOVERY_PATHS` – iterable of dotted module paths to import during discovery. The defaults
+  import OrchestrAI’s contrib provider backends/codecs and include glob patterns for common
+  project layouts (`*.orca.services`, `*.orca.output_schemas`, `*.orca.codecs`, `*.ai.services`).
+  Patterns resolve to real modules before import; unmatched patterns are skipped safely.
 - `LOADER` – dotted path to a loader class; defaults to the lightweight base loader.
 - `MODE` – optional runtime mode flag.
 
@@ -83,12 +86,19 @@ Nested contexts restore the previous app automatically.
 
 ## Discovery and loaders
 
-The default loader performs no implicit work until `discover()` is called. Provide `DISCOVERY_PATHS` to import modules that register services, codecs, or other components.
+The default loader performs no implicit work until `discover()` is called. By default it imports
+OrchestrAI contrib registration modules plus any modules matching the built-in glob patterns.
+Provide your own `DISCOVERY_PATHS` tuple to extend or override that list, or set it to an empty
+tuple to disable all automatic discovery.
 
 ```python
 app.configure({"DISCOVERY_PATHS": ["myapp.services", "myapp.codecs"]})
 app.discover()
 ```
+
+The defaults already scan `orchestrai.contrib.provider_backends` and
+`orchestrai.contrib.provider_codecs`, and attempt to import modules matching `*.orca.services`,
+`*.orca.output_schemas`, `*.orca.codecs`, and `*.ai.services` when they exist on `sys.path`.
 
 If you need custom behavior, point `LOADER` to your own loader class implementing `autodiscover(app, modules)`.
 

--- a/packages/orchestrai/docs/quick_start.md
+++ b/packages/orchestrai/docs/quick_start.md
@@ -21,10 +21,18 @@ app.configure(
         "CLIENT": "demo-client",
         "CLIENTS": {"demo-client": {"name": "demo-client", "api_key": "token"}},
         "PROVIDERS": {"demo": {"backend": "openai", "model": "gpt-4o-mini"}},
+        # DISCOVERY_PATHS defaults to built-in contrib modules plus glob patterns such as
+        # "*.orca.services" and "*.ai.services". Override to add custom modules or set to an
+        # empty tuple to disable automatic discovery entirely.
         "DISCOVERY_PATHS": ["my_project.services"],
     }
 )
 ```
+
+If your project follows the `orca` or `ai` conventions (for example `my_project/orca/services`),
+the defaults will attempt to import those modules automatically. Provide your own
+`DISCOVERY_PATHS` list to opt into other modules or set it to an empty tuple `()` to skip
+autodiscovery altogether.
 
 ## 3. Run the lifecycle
 

--- a/packages/orchestrai/src/orchestrai/conf/defaults.py
+++ b/packages/orchestrai/src/orchestrai/conf/defaults.py
@@ -5,9 +5,15 @@ DEFAULTS: dict[str, object] = {
     "CLIENT": None,
     "CLIENTS": {},
     "PROVIDERS": {},
-    "DISCOVERY_PATHS": (),
+    "DISCOVERY_PATHS": (
+        "orchestrai.contrib.provider_backends",
+        "orchestrai.contrib.provider_codecs",
+        "*.orca.services",
+        "*.orca.output_schemas",
+        "*.orca.codecs",
+        "*.ai.services",
+    ),
     "FIXUPS": (),
     "LOADER": "orchestrai.loaders.default:DefaultLoader",
     "IDENTITY_STRIP_TOKENS": tuple(),
 }
-

--- a/packages/orchestrai/src/orchestrai/contrib/provider_codecs/__init__.py
+++ b/packages/orchestrai/src/orchestrai/contrib/provider_codecs/__init__.py
@@ -1,0 +1,9 @@
+"""Built-in provider codecs shipped with OrchestrAI."""
+
+# Import OpenAI codecs so they register with the global registry on module import.
+# Additional provider codec packages can follow the same pattern.
+from .openai import *  # noqa: F401,F403
+
+__all__ = (
+    "OpenAIResponsesJsonCodec",
+)

--- a/packages/orchestrai/src/orchestrai/loaders/default.py
+++ b/packages/orchestrai/src/orchestrai/loaders/default.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import glob
 import importlib
 import os
+import sys
 from typing import Iterable, List
 
 from .base import BaseLoader
@@ -19,10 +21,63 @@ class DefaultLoader(BaseLoader):
 
     def autodiscover(self, app, modules: Iterable[str]) -> List[str]:
         imported: list[str] = []
-        for module in modules:
-            if not module:
-                continue
+        for module in self._resolve_modules(modules):
             importlib.import_module(module)
             imported.append(module)
         return imported
 
+    def _resolve_modules(self, modules: Iterable[str]) -> list[str]:
+        resolved: list[str] = []
+        for module in modules:
+            if not module:
+                continue
+            if self._is_pattern(module):
+                resolved.extend(self._expand_pattern(module))
+            else:
+                resolved.append(module)
+        return self._dedupe(resolved)
+
+    def _expand_pattern(self, pattern: str) -> list[str]:
+        matches: list[str] = []
+        module_path_pattern = pattern.replace(".", os.sep)
+        for base in sys.path:
+            if not base or not os.path.isdir(base):
+                continue
+            for suffix in ("", ".py", f"{os.sep}__init__.py"):
+                glob_pattern = os.path.join(base, f"{module_path_pattern}{suffix}")
+                for candidate in glob.glob(glob_pattern):
+                    module_name = self._module_name_from_path(candidate, base)
+                    if not module_name:
+                        continue
+                    if importlib.util.find_spec(module_name) and module_name not in matches:
+                        matches.append(module_name)
+        return matches
+
+    @staticmethod
+    def _module_name_from_path(candidate: str, base_path: str) -> str | None:
+        rel_path = os.path.relpath(candidate, base_path)
+        if rel_path.startswith(os.pardir):
+            return None
+
+        rel_path = rel_path.replace(os.sep, ".")
+        for suffix in (".__init__.py", ".py"):
+            if rel_path.endswith(suffix):
+                rel_path = rel_path[: -len(suffix)]
+                break
+
+        rel_path = rel_path.rstrip(".")
+        return rel_path or None
+
+    @staticmethod
+    def _dedupe(items: Iterable[str]) -> list[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for item in items:
+            if item and item not in seen:
+                seen.add(item)
+                ordered.append(item)
+        return ordered
+
+    @staticmethod
+    def _is_pattern(value: str) -> bool:
+        return any(char in value for char in "*?[")

--- a/tests/orchestrai/test_default_loader.py
+++ b/tests/orchestrai/test_default_loader.py
@@ -1,0 +1,56 @@
+import sys
+
+from orchestrai import OrchestrAI
+from orchestrai.conf.defaults import DEFAULTS
+from orchestrai.loaders.default import DefaultLoader
+from orchestrai.registry import singletons
+
+
+def test_default_discovery_paths_include_contrib_and_patterns():
+    discovery_paths = DEFAULTS["DISCOVERY_PATHS"]
+    expected = [
+        "orchestrai.contrib.provider_backends",
+        "orchestrai.contrib.provider_codecs",
+        "*.orca.services",
+        "*.orca.output_schemas",
+        "*.orca.codecs",
+        "*.ai.services",
+    ]
+
+    for path in expected:
+        assert path in discovery_paths
+
+
+def test_default_loader_expands_glob_patterns(monkeypatch, tmp_path):
+    package_root = tmp_path / "demo_pkg"
+    services_dir = package_root / "orca" / "services"
+    services_dir.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "orca" / "__init__.py").write_text("", encoding="utf-8")
+    (services_dir / "__init__.py").write_text("IMPORTED = True\n", encoding="utf-8")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for module in ("demo_pkg", "demo_pkg.orca", "demo_pkg.orca.services"):
+        monkeypatch.delitem(sys.modules, module, raising=False)
+
+    loader = DefaultLoader()
+    imported = loader.autodiscover(None, ["*.orca.services", "*.missing.module"])
+
+    assert imported == ["demo_pkg.orca.services"]
+    assert sys.modules["demo_pkg.orca.services"].IMPORTED is True
+
+
+def test_default_loader_imports_contrib_codecs(monkeypatch):
+    # Ensure global registry starts clean for this assertion.
+    singletons.codecs.clear()
+
+    # Remove contrib modules to force the loader to import them.
+    for module_name in list(sys.modules):
+        if module_name.startswith("orchestrai.contrib.provider_codecs"):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    app = OrchestrAI()
+    app.start()
+
+    codec_labels = app.codecs.all()
+    assert "openai.responses.json" in codec_labels


### PR DESCRIPTION
## Summary
- add contrib registration modules and common project glob patterns to default `DISCOVERY_PATHS`
- expand the default loader to resolve glob patterns safely before import
- ensure contrib provider codecs import their OpenAI Responses codec so default discovery registers it
- document the new discovery defaults and add coverage for pattern expansion

## Testing
- uv run pytest packages/orchestrai *(fails: unable to download pytest dependency in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ac8bae4883339c8570eebdcccc33)