### PR TITLE
Add fixup stages and tighten OrchestrAI lifecycle

### DIFF
--- a/packages/orchestrai/src/orchestrai/fixups/__init__.py
+++ b/packages/orchestrai/src/orchestrai/fixups/__init__.py
@@ -1,5 +1,5 @@
 """Framework fixups for OrchestrAI integrations."""
 
-from .base import BaseFixup
+from .base import Fixup, FixupStage, LoggingFixup, NoOpFixup
 
-__all__ = ["BaseFixup"]
+__all__ = ["Fixup", "FixupStage", "LoggingFixup", "NoOpFixup"]

--- a/packages/orchestrai/src/orchestrai/fixups/base.py
+++ b/packages/orchestrai/src/orchestrai/fixups/base.py
@@ -1,22 +1,50 @@
-"""Fixup interfaces for framework integrations."""
+"""Fixup interfaces and built-in helpers."""
 
 from __future__ import annotations
 
-from typing import Iterable
+import logging
+from enum import Enum, auto
+from typing import Any, Protocol, runtime_checkable
 
 
-class BaseFixup:
-    """Hooks called during app lifecycle."""
+class FixupStage(Enum):
+    """Lifecycle checkpoints that fixups can observe."""
 
-    def on_app_init(self, app) -> None:  # pragma: no cover - default noop
+    CONFIGURE_PRE = auto()
+    CONFIGURE_POST = auto()
+    START_PRE = auto()
+    START_POST = auto()
+    AUTODISCOVER_PRE = auto()
+    AUTODISCOVER_POST = auto()
+    FINALIZE_PRE = auto()
+    FINALIZE_POST = auto()
+    ENSURE_READY_PRE = auto()
+    ENSURE_READY_POST = auto()
+
+
+@runtime_checkable
+class Fixup(Protocol):
+    """A callable hook invoked at lifecycle checkpoints."""
+
+    def apply(self, stage: FixupStage, app: Any, **context: Any) -> Any:
+        ...
+
+
+class NoOpFixup:
+    """A fixup that intentionally does nothing."""
+
+    def apply(self, stage: FixupStage, app: Any, **context: Any) -> None:  # pragma: no cover
         return None
 
-    def on_setup(self, app) -> None:  # pragma: no cover - default noop
-        return None
 
-    def on_import_modules(self, app, modules: Iterable[str]) -> None:  # pragma: no cover
-        return None
+class LoggingFixup:
+    """Log every lifecycle stage observed by the application."""
 
-    def autodiscover_sources(self, app) -> Iterable[str]:  # pragma: no cover - default empty
-        return []
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
 
+    def apply(self, stage: FixupStage, app: Any, **context: Any) -> None:
+        self.logger.info("[%s] %s", app.name, stage.name)
+
+
+__all__ = ["Fixup", "FixupStage", "LoggingFixup", "NoOpFixup"]


### PR DESCRIPTION
## Summary
- introduce FixupStage enum, Fixup protocol, and built-in no-op/logging fixups
- add per-app fixup management plus lifecycle hooks across configure/start/discover/finalize/ensure_ready
- guard readiness flow with reentrant locking and explicit configure→start→discover→finalize order

## Testing
- uv run pytest packages/orchestrai *(fails: unable to download dependency `opentelemetry-proto` due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941ccdaf5d88333a6e2861ec81a6ea2)