### PR TITLE
Add resolver pipeline for services

### DIFF
--- a/packages/orchestrai/src/orchestrai/resolve/__init__.py
+++ b/packages/orchestrai/src/orchestrai/resolve/__init__.py
@@ -1,0 +1,15 @@
+"""Resolver helpers for OrchestrAI components."""
+
+from .result import ResolutionBranch, ResolutionResult
+from .schema import resolve_schema, apply_schema_adapters
+from .codec import resolve_codec
+from .prompt_plan import resolve_prompt_plan
+
+__all__ = [
+    "ResolutionBranch",
+    "ResolutionResult",
+    "resolve_schema",
+    "apply_schema_adapters",
+    "resolve_codec",
+    "resolve_prompt_plan",
+]

--- a/packages/orchestrai/src/orchestrai/resolve/codec.py
+++ b/packages/orchestrai/src/orchestrai/resolve/codec.py
@@ -1,0 +1,123 @@
+"""Codec resolver with precedence and priority-aware tie-breaking."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from orchestrai.components.codecs import BaseCodec
+
+from .result import ResolutionBranch, ResolutionResult
+
+logger = logging.getLogger(__name__)
+
+
+def _codec_identity_label(codec_cls: type[BaseCodec]) -> str | None:
+    ident = getattr(codec_cls, "identity", None)
+    return getattr(ident, "as_str", None) or getattr(ident, "label", None)
+
+
+def _unique(seq: Iterable) -> list:
+    out = []
+    for item in seq:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def _matches_constraints(codec_cls: type[BaseCodec], constraints: dict[str, object]) -> bool:
+    if not constraints:
+        return True
+    matches = getattr(codec_cls, "matches", None)
+    if not callable(matches):
+        return False
+    try:
+        return bool(matches(**constraints))
+    except Exception:
+        logger.debug("codec constraint check failed for %s", codec_cls, exc_info=True)
+        return False
+
+
+def _sort_candidates(candidates: list[type[BaseCodec]]) -> list[type[BaseCodec]]:
+    def _priority(cls: type[BaseCodec]) -> tuple[int, str]:
+        prio = getattr(cls, "priority", 0)
+        label = _codec_identity_label(cls) or getattr(cls, "__name__", "")
+        return int(prio), label
+
+    return sorted(candidates, key=_priority, reverse=True)
+
+
+def resolve_codec(
+        *,
+        service,
+        override: type[BaseCodec] | None = None,
+        explicit: type[BaseCodec] | None = None,
+        configured: Iterable[type[BaseCodec]] | None = None,
+        constraints: dict[str, object] | None = None,
+        store=None,
+) -> ResolutionResult[type[BaseCodec] | None]:
+    """Resolve a codec class for a service call."""
+
+    if store is None:
+        store = getattr(service, "component_store", None)
+    if store is None:
+        from orchestrai.registry.active_app import get_component_store as _get_component_store
+
+        store = _get_component_store()
+    branches: list[ResolutionBranch[type[BaseCodec] | None]] = []
+
+    if override is not None:
+        branch = ResolutionBranch(
+            "override",
+            override,
+            identity=_codec_identity_label(override),
+            reason="per-call codec override",
+        )
+        return ResolutionResult(override, branch, branches + [branch])
+
+    if explicit is not None:
+        branch = ResolutionBranch(
+            "explicit",
+            explicit,
+            identity=_codec_identity_label(explicit),
+            reason="codec_cls provided",
+        )
+        return ResolutionResult(explicit, branch, branches + [branch])
+
+    candidates: list[type[BaseCodec]] = []
+
+    for cand in configured or ():
+        if cand not in candidates:
+            candidates.append(cand)
+
+    registry_candidates: list[type[BaseCodec]] = []
+    if store is not None and constraints:
+        try:
+            registry = store.registry("codec")
+            for cand in registry.items():
+                if _matches_constraints(cand, constraints):
+                    registry_candidates.append(cand)
+        except Exception:
+            logger.debug("codec resolution: registry lookup failed", exc_info=True)
+
+    candidates.extend(x for x in registry_candidates if x not in candidates)
+
+    if candidates:
+        selected = _sort_candidates(candidates)[0]
+        branch = ResolutionBranch(
+            "candidates",
+            selected,
+            identity=_codec_identity_label(selected),
+            reason="selected best matching codec",
+            meta={
+                "candidates": tuple(_codec_identity_label(c) or str(c) for c in candidates),
+                "candidate_classes": tuple(candidates),
+            },
+        )
+        return ResolutionResult(selected, branch, _unique(branches + [branch]))
+
+    branch = ResolutionBranch("none", None, reason="no codec resolved")
+    return ResolutionResult(None, branch, branches + [branch])
+
+
+__all__ = ["resolve_codec"]

--- a/packages/orchestrai/src/orchestrai/resolve/prompt_plan.py
+++ b/packages/orchestrai/src/orchestrai/resolve/prompt_plan.py
@@ -1,0 +1,69 @@
+"""Prompt plan resolver."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from orchestrai.components.promptkit import PromptPlan, PromptSection
+from orchestrai.identity import Identity
+
+from .result import ResolutionBranch, ResolutionResult
+
+logger = logging.getLogger(__name__)
+
+
+def _iter_unique(seq: Iterable) -> list:
+    out = []
+    for item in seq:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def resolve_prompt_plan(service) -> ResolutionResult[PromptPlan | None]:
+    """Resolve the prompt plan for a service (explicit → registry → none)."""
+
+    store = getattr(service, "component_store", None)
+    if store is None:
+        from orchestrai.registry.active_app import get_component_store as _get_component_store
+
+        store = _get_component_store()
+    branches: list[ResolutionBranch[PromptPlan | None]] = []
+
+    # Explicit plan (ctor or class default, pre-normalized in the service)
+    if getattr(service, "_prompt_plan", None) is not None:
+        plan = service._prompt_plan
+        branch = ResolutionBranch(
+            "explicit",
+            plan,
+            reason=f"provided via {getattr(service, '_prompt_plan_source', 'explicit')}",
+        )
+        return ResolutionResult(plan, branch, _iter_unique(branches + [branch]))
+
+    # Registry match: prompt section whose identity matches the service
+    section_cls = None
+    if store is not None:
+        lookup_ident = getattr(service, "identity", None)
+        if isinstance(lookup_ident, Identity):
+            lookup_ident = Identity(namespace=lookup_ident.namespace, kind="prompt_section", name=lookup_ident.name)
+        try:
+            section_cls = store.try_get("prompt_section", lookup_ident or service.identity)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("prompt plan resolution: prompt_section lookup failed", exc_info=True)
+
+    if section_cls is not None:
+        plan = PromptPlan.from_sections([section_cls])
+        branch = ResolutionBranch(
+            "registry",
+            plan,
+            identity=getattr(section_cls, "identity", None).as_str if hasattr(section_cls, "identity") else None,
+            reason="matched prompt_section in ComponentStore",
+        )
+        return ResolutionResult(plan, branch, _iter_unique(branches + [branch]))
+
+    branch = ResolutionBranch("none", None, reason="no prompt plan available")
+    return ResolutionResult(None, branch, _iter_unique(branches + [branch]))
+
+
+__all__ = ["resolve_prompt_plan"]

--- a/packages/orchestrai/src/orchestrai/resolve/result.py
+++ b/packages/orchestrai/src/orchestrai/resolve/result.py
@@ -1,0 +1,60 @@
+"""Resolution helpers with branch tracing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class ResolutionBranch(Generic[T]):
+    """A single resolution attempt/branch."""
+
+    name: str
+    value: T | None
+    reason: str | None = None
+    identity: str | None = None
+    meta: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ResolutionResult(Generic[T]):
+    """Aggregate result of a resolver with branch history."""
+
+    value: T | None
+    selected: ResolutionBranch[T]
+    branches: list[ResolutionBranch[T]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.selected not in self.branches:
+            self.branches.insert(0, self.selected)
+
+    @property
+    def branch(self) -> str:
+        return self.selected.name
+
+    def context(self, prefix: str) -> dict[str, object]:
+        """Return a shallow context mapping for tracing."""
+
+        ctx: dict[str, object] = {
+            f"{prefix}.branch": self.selected.name,
+            f"{prefix}.reason": self.selected.reason or "",
+            f"{prefix}.identity": self.selected.identity or "<none>",
+        }
+
+        # Preserve compact branch history for debugging (branch:identity pairs)
+        history: list[str] = []
+        for br in self.branches:
+            label = br.identity or "<none>"
+            history.append(f"{br.name}:{label}")
+        ctx[f"{prefix}.branches"] = " | ".join(history)
+        return ctx
+
+
+__all__ = [
+    "ResolutionBranch",
+    "ResolutionResult",
+]

--- a/packages/orchestrai/src/orchestrai/resolve/schema.py
+++ b/packages/orchestrai/src/orchestrai/resolve/schema.py
@@ -1,0 +1,104 @@
+"""Response schema resolver with adapter application."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from orchestrai.components.schemas import BaseOutputSchema, sort_adapters
+from orchestrai.identity import Identity
+
+from .result import ResolutionBranch, ResolutionResult
+
+logger = logging.getLogger(__name__)
+
+
+def apply_schema_adapters(
+        schema_cls: type[BaseOutputSchema] | None,
+        adapters: Iterable,
+) -> dict | None:
+    """Return an adapted JSON schema when a model and adapters exist."""
+
+    if schema_cls is None:
+        return None
+
+    try:
+        schema_json = schema_cls.model_json_schema()
+    except Exception:
+        logger.debug("schema resolution: model_json_schema failed", exc_info=True)
+        return None
+
+    out = schema_json
+    for adapter in sort_adapters(adapters or ()):  # type: ignore[arg-type]
+        try:
+            out = adapter.adapt(out)
+        except Exception:  # pragma: no cover - adapter bugs should surface clearly
+            logger.debug("schema adapter %r failed", adapter, exc_info=True)
+            raise
+    return out
+
+
+def resolve_schema(
+        *,
+        identity,
+        override: type[BaseOutputSchema] | None = None,
+        default: type[BaseOutputSchema] | None = None,
+        adapters: Iterable | None = None,
+        store=None,
+) -> ResolutionResult[type[BaseOutputSchema] | None]:
+    """Resolve a response schema with simple precedence."""
+
+    if store is None:
+        from orchestrai.registry.active_app import get_component_store as _get_component_store
+
+        store = _get_component_store()
+    branches: list[ResolutionBranch[type[BaseOutputSchema] | None]] = []
+
+    if override is not None:
+        branch = ResolutionBranch(
+            "override",
+            override,
+            identity=getattr(override, "identity", None).as_str if hasattr(override, "identity") else None,
+            reason="response_schema override provided",
+        )
+        branch.meta["schema_json"] = apply_schema_adapters(override, adapters or ())
+        return ResolutionResult(override, branch, branches + [branch])
+
+    if default is not None:
+        branch = ResolutionBranch(
+            "class",
+            default,
+            identity=getattr(default, "identity", None).as_str if hasattr(default, "identity") else None,
+            reason="class-level response_schema",
+        )
+        branch.meta["schema_json"] = apply_schema_adapters(default, adapters or ())
+        return ResolutionResult(default, branch, branches + [branch])
+
+    candidate = None
+    if store is not None:
+        lookup_ident = identity
+        if isinstance(identity, Identity):
+            lookup_ident = Identity(namespace=identity.namespace, kind="schema", name=identity.name)
+        try:
+            candidate = store.try_get("schema", lookup_ident)
+        except Exception:
+            logger.debug("schema resolution: ComponentStore lookup failed", exc_info=True)
+
+    if candidate is not None:
+        branch = ResolutionBranch(
+            "registry",
+            candidate,
+            identity=getattr(candidate, "identity", None).as_str if hasattr(candidate, "identity") else None,
+            reason="matched schema in ComponentStore",
+        )
+        branch.meta["schema_json"] = apply_schema_adapters(candidate, adapters or ())
+        return ResolutionResult(candidate, branch, branches + [branch])
+
+    branch = ResolutionBranch("none", None, reason="no response schema resolved")
+    return ResolutionResult(None, branch, branches + [branch])
+
+
+__all__ = [
+    "apply_schema_adapters",
+    "resolve_schema",
+]

--- a/packages/orchestrai/tests/conftest.py
+++ b/packages/orchestrai/tests/conftest.py
@@ -1,0 +1,108 @@
+import asyncio
+import sys
+import types
+
+# Provide a minimal asgiref.sync stub when the dependency is unavailable in the
+# execution environment. This is sufficient for tests that rely on the sync
+# wrappers but do not require thread-sensitive behavior.
+if "asgiref" not in sys.modules:
+    asgiref_mod = types.ModuleType("asgiref")
+    sync_mod = types.ModuleType("asgiref.sync")
+
+    def async_to_sync(func):
+        def wrapper(*args, **kwargs):
+            return asyncio.get_event_loop().run_until_complete(func(*args, **kwargs))
+        return wrapper
+
+    def sync_to_async(func):
+        async def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+
+    sync_mod.async_to_sync = async_to_sync
+    sync_mod.sync_to_async = sync_to_async
+    asgiref_mod.sync = sync_mod
+
+    sys.modules["asgiref"] = asgiref_mod
+    sys.modules["asgiref.sync"] = sync_mod
+
+
+if "logfire" not in sys.modules:
+    logfire_mod = types.SimpleNamespace(error=lambda *args, **kwargs: None)
+    sys.modules["logfire"] = logfire_mod
+
+
+if "slugify" not in sys.modules:
+    slug_mod = types.SimpleNamespace(slugify=lambda value, **kwargs: str(value))
+    sys.modules["slugify"] = slug_mod
+
+
+if "pydantic" not in sys.modules:
+    pydantic_mod = types.ModuleType("pydantic")
+
+    class ValidationError(Exception):
+        pass
+
+    class ConfigDict(dict):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
+    class BaseModel:
+        model_config = {}
+
+        def __init__(self, **data):
+            for key, value in data.items():
+                setattr(self, key, value)
+
+        @classmethod
+        def model_json_schema(cls):
+            props = {k: {"title": k} for k in getattr(cls, "__annotations__", {})}
+            return {"title": cls.__name__, "type": "object", "properties": props}
+
+        @classmethod
+        def model_construct(cls, **kwargs):
+            return cls(**kwargs)
+
+        @classmethod
+        def model_validate(cls, data):
+            return cls(**data)
+
+    class RootModel(BaseModel):
+        def __init__(self, root=None, **kwargs):
+            super().__init__(root=root, **kwargs)
+
+        def __class_getitem__(cls, item):
+            return cls
+
+    def Field(default=None, **kwargs):
+        return default
+
+    def field_serializer(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    def field_validator(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    def model_validator(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    pydantic_mod.BaseModel = BaseModel
+    pydantic_mod.ConfigDict = ConfigDict
+    pydantic_mod.ValidationError = ValidationError
+    pydantic_mod.RootModel = RootModel
+    pydantic_mod.Field = Field
+    pydantic_mod.field_serializer = field_serializer
+    pydantic_mod.field_validator = field_validator
+    pydantic_mod.model_validator = model_validator
+
+    config_mod = types.ModuleType("pydantic.config")
+    config_mod.ConfigDict = ConfigDict
+
+    sys.modules["pydantic"] = pydantic_mod
+    sys.modules["pydantic.config"] = config_mod

--- a/packages/orchestrai/tests/test_resolvers.py
+++ b/packages/orchestrai/tests/test_resolvers.py
@@ -1,0 +1,197 @@
+import pytest
+
+from orchestrai.components.codecs import BaseCodec
+from orchestrai.components.promptkit import PromptPlan, PromptSection
+from orchestrai.components.schemas import BaseOutputSchema
+from orchestrai.contrib.provider_backends.openai.schema_adapters import OpenaiWrapper
+from orchestrai.identity import Identity
+from orchestrai.registry import ComponentStore
+from orchestrai.registry.records import RegistrationRecord
+from orchestrai.registry.active_app import set_active_registry_app
+from orchestrai.resolve import resolve_codec, resolve_prompt_plan, resolve_schema
+from orchestrai.components.services.service import BaseService
+
+
+class DemoSchema(BaseOutputSchema):
+    identity = Identity("demo", "schema", "svc")
+    foo: str
+
+
+class DemoPrompt(PromptSection):
+    abstract = False
+    identity = Identity("demo", "prompt_section", "svc")
+    instruction = "hello"
+    message = "world"
+
+
+class AltPrompt(PromptSection):
+    abstract = False
+    identity = Identity("demo", "prompt_section", "alt")
+    instruction = "alt"
+
+
+class LowCodec(BaseCodec):
+    abstract = False
+    identity = Identity("demo", "codec", "low")
+    priority = 1
+    response_schema = DemoSchema
+
+    @classmethod
+    def matches(cls, *, provider, api, result_type):
+        return provider == "demo" and result_type == "json"
+
+
+class HighCodec(BaseCodec):
+    abstract = False
+    identity = Identity("demo", "codec", "high")
+    priority = 5
+    response_schema = DemoSchema
+
+    @classmethod
+    def matches(cls, *, provider, api, result_type):
+        return provider == "demo" and result_type == "json"
+
+
+class AdapterCodec(BaseCodec):
+    abstract = False
+    identity = Identity("demo", "codec", "adapter")
+    response_schema = DemoSchema
+    schema_adapters = (OpenaiWrapper(order=0),)
+
+    @classmethod
+    def matches(cls, *, provider, api, result_type):
+        return provider == "demo" and result_type == "json"
+
+
+class DemoService(BaseService):
+    abstract = False
+    identity = Identity("demo", "service", "svc")
+    provider_name = "demo"
+
+
+@pytest.fixture()
+def store():
+    return ComponentStore()
+
+
+def register(store: ComponentStore, component) -> None:
+    store.register(RegistrationRecord(component=component, identity=component.identity))
+
+
+def attach_store(store: ComponentStore) -> None:
+    app = type("App", (), {"component_store": store})()
+    set_active_registry_app(app)
+
+
+def test_prompt_plan_resolution_branches(store):
+    # explicit
+    explicit_plan = PromptPlan.from_sections([DemoPrompt])
+    svc_explicit = DemoService(prompt_plan=explicit_plan)
+    res_explicit = resolve_prompt_plan(svc_explicit)
+    assert res_explicit.branch == "explicit"
+    assert res_explicit.value is explicit_plan
+
+    # registry
+    register(store, DemoPrompt)
+    attach_store(store)
+    svc_registry = DemoService()
+    res_registry = resolve_prompt_plan(svc_registry)
+    assert res_registry.branch == "registry"
+    assert isinstance(res_registry.value, PromptPlan)
+
+    # none
+    attach_store(ComponentStore())
+    svc_none = DemoService()
+    res_none = resolve_prompt_plan(svc_none)
+    assert res_none.branch == "none"
+    assert res_none.value is None
+
+
+def test_schema_resolution_branches(store):
+    ident = Identity("demo", "service", "svc")
+
+    # override wins
+    res_override = resolve_schema(identity=ident, override=DemoSchema, store=store)
+    assert res_override.branch == "override"
+    assert res_override.value is DemoSchema
+
+    # class default
+    res_class = resolve_schema(identity=ident, default=DemoSchema, store=store)
+    assert res_class.branch == "class"
+
+    # registry lookup
+    register(store, DemoSchema)
+    attach_store(store)
+    res_registry = resolve_schema(identity=ident, store=store)
+    assert res_registry.branch == "registry"
+    assert res_registry.value is DemoSchema
+
+    # none branch
+    empty = ComponentStore()
+    res_none = resolve_schema(identity=ident, store=empty)
+    assert res_none.branch == "none"
+    assert res_none.value is None
+
+
+def test_schema_adapter_application():
+    ident = Identity("demo", "service", "svc")
+    res = resolve_schema(identity=ident, override=DemoSchema, adapters=AdapterCodec.schema_adapters)
+    schema_json = res.selected.meta.get("schema_json")
+    assert res.branch == "override"
+    assert schema_json is not None
+    assert schema_json.get("type") == "json_schema"
+    assert "json_schema" in schema_json
+
+
+def test_codec_resolution_branches(store):
+    svc = DemoService()
+    attach_store(store)
+
+    res_override = resolve_codec(service=svc, override=HighCodec)
+    assert res_override.branch == "override"
+    assert res_override.value is HighCodec
+
+    res_explicit = resolve_codec(service=svc, explicit=LowCodec)
+    assert res_explicit.branch == "explicit"
+    assert res_explicit.value is LowCodec
+
+    register(store, LowCodec)
+    register(store, HighCodec)
+    constraints = {"provider": "demo", "api": "responses", "result_type": "json"}
+    res_candidates = resolve_codec(service=svc, constraints=constraints, store=store)
+    assert res_candidates.branch == "candidates"
+    assert res_candidates.value is HighCodec
+    assert HighCodec in res_candidates.selected.meta.get("candidate_classes", ())
+
+    res_none = resolve_codec(service=svc, store=ComponentStore())
+    assert res_none.branch == "none"
+    assert res_none.value is None
+
+
+def test_service_prepare_end_to_end(store):
+    register(store, DemoPrompt)
+    register(store, DemoSchema)
+    register(store, AdapterCodec)
+
+    attach_store(store)
+    svc = DemoService()
+
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        req, codec, attrs = loop.run_until_complete(svc.aprepare(stream=False))
+    finally:
+        loop.close()
+
+    assert codec is not None
+    assert req.response_schema_json is not None
+    assert req.provider_response_format == req.response_schema_json
+    assert req.response_schema_json.get("type") == "json_schema"
+
+    # Context should record branches/identities
+    assert svc.context.get("schema.branch") == "registry"
+    assert "codec.branch" in svc.context
+    assert "prompt.plan.branch" in svc.context
+    assert attrs["codec"] == svc.context.get("service.codec.label")


### PR DESCRIPTION
## Summary
- add resolution helpers with branch tracing for prompt plans, schemas, and codecs tied to the ComponentStore
- refactor BaseService to use the new resolvers, propagate resolution context, and apply codec schema adapters
- add regression coverage for resolver branches, codec tie-breaking, schema adapters, and service preparation

## Testing
- PYTHONPATH=packages/orchestrai/src pytest packages/orchestrai/tests/test_resolvers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cfebed308333ae9afbaa111cd5f3)