### PR TITLE
Normalize identity resolution domains

### DIFF
--- a/packages/orchestrai/src/orchestrai/identity/constants.py
+++ b/packages/orchestrai/src/orchestrai/identity/constants.py
@@ -1,0 +1,30 @@
+"""Canonical identity constants shared across the identity layer."""
+
+import re
+from typing import Optional
+
+__all__ = ["DEFAULT_DOMAIN", "normalize_domain"]
+
+DEFAULT_DOMAIN = "default"
+
+
+def normalize_domain(value: Optional[str], *, default: str | None = DEFAULT_DOMAIN) -> str:
+    """Normalize a domain value, applying a canonical default when missing.
+
+    Normalization collapses dots/underscores/hyphens/spaces into single hyphens,
+    lowercases the result, and trims edges. A ``ValueError`` is raised if no
+    usable value is provided and no ``default`` is supplied.
+    """
+    candidate = value if value is not None else default
+    if candidate is None:
+        raise ValueError("domain is required")
+    if not isinstance(candidate, str):
+        raise TypeError(f"domain must be a string (got {type(candidate)!r})")
+
+    normalized = re.sub(r"[._\\s\-]+", "-", candidate.strip())
+    normalized = re.sub(r"-{2,}", "-", normalized).strip("-").lower()
+    if not normalized:
+        if default is None:
+            raise ValueError("domain cannot be empty")
+        return normalize_domain(default, default=None)
+    return normalized

--- a/packages/orchestrai/src/orchestrai/identity/identity.py
+++ b/packages/orchestrai/src/orchestrai/identity/identity.py
@@ -184,7 +184,7 @@ class Identity:
         if isinstance(value, IdentityKey):
             return _from_key(value)
 
-        # Tuple3
+        # Tuple4
         if isinstance(value, tuple):
             return _from_tuple(value)
 

--- a/packages/orchestrai/tests/test_identity_core.py
+++ b/packages/orchestrai/tests/test_identity_core.py
@@ -1,0 +1,46 @@
+import pytest
+
+from orchestrai.identity import Identity, IdentityResolver
+
+
+def test_domain_precedence_and_normalization_default_context():
+    class Demo:
+        namespace = "DemoSpace"
+        group = "Group"
+        name = "ExplicitName"
+
+    ident, meta = IdentityResolver().resolve(Demo, context={"default_domain": "SIM.Core"})
+
+    assert ident.domain == "sim-core"
+    assert meta["simcore.identity.source.domain"] == "default"
+    assert ident.namespace == "demo_space"
+    assert ident.group == "group"
+    assert ident.name == "ExplicitName"
+    assert meta["simcore.tuple4.post_norm"] == ident.as_str
+
+
+@pytest.mark.parametrize(
+    "domain_arg, domain_attr, expected, source",
+    [
+        ("Explicit", "AttrDomain", "explicit", "arg"),
+        (None, "AttrDomain", "attrdomain", "attr"),
+    ],
+)
+def test_domain_arg_overrides_and_attr_precedence(domain_arg, domain_attr, expected, source):
+    class Demo:
+        domain = domain_attr
+        namespace = "demo"
+        group = "demo"
+
+    ident, meta = IdentityResolver().resolve(Demo, domain=domain_arg)
+
+    assert ident.domain == expected
+    assert meta["simcore.identity.source.domain"] == source
+
+
+def test_resolve_facade_tuple_helpers_are_four_part_only():
+    ident = Identity(domain="d", namespace="n", group="g", name="x")
+
+    assert Identity.resolve.as_tuple(ident) == ("d", "n", "g", "x")
+    assert Identity.resolve.as_tuple4(ident) == ("d", "n", "g", "x")
+    assert Identity.resolve.as_label(ident) == "d.n.g.x"

--- a/packages/orchestrai_django/src/orchestrai_django/decorators.py
+++ b/packages/orchestrai_django/src/orchestrai_django/decorators.py
@@ -22,6 +22,7 @@ from orchestrai.decorators.components.codec_decorator import CodecDecorator
 from orchestrai.decorators.components.prompt_section_decorator import PromptSectionDecorator
 from orchestrai.decorators.components.schema_decorator import SchemaDecorator
 from orchestrai.decorators.components.service_decorator import ServiceDecorator
+from orchestrai.identity.constants import DEFAULT_DOMAIN
 from orchestrai_django.identity.resolvers import DjangoIdentityResolver
 
 __all__ = [
@@ -41,15 +42,23 @@ class DjangoBaseDecoratorMixin:
             self,
             cls,  # type: ignore[no-untyped-def]
             *,
+            domain: str | None,
             namespace: str | None,
-            kind: str | None,
+            group: str | None,
             name: str | None,
     ):
+        context = {
+            "default_domain": getattr(self, "default_domain", DEFAULT_DOMAIN),
+            "default_namespace": getattr(self, "default_namespace", None),
+            "default_group": getattr(self, "default_group", None),
+        }
         return DjangoIdentityResolver().resolve(
             cls,
+            domain=domain,
             namespace=namespace,
-            kind=kind,
+            group=group,
             name=name,
+            context=context,
         )
 
     # Optional collision policy hook for registries.

--- a/packages/orchestrai_django/src/orchestrai_django/identity/resolvers.py
+++ b/packages/orchestrai_django/src/orchestrai_django/identity/resolvers.py
@@ -185,11 +185,19 @@ class DjangoIdentityResolver(IdentityResolver):
 def resolve_identity_django(
         cls: type,
         *,
+        domain: Optional[str] = None,
         namespace: Optional[str] = None,
-        kind: Optional[str] = None,
+        group: Optional[str] = None,
         name: Optional[str] = None,
         context: Optional[dict[str, Any]] = None,
 ) -> tuple["Identity", dict[str, Any]]:
     r = DjangoIdentityResolver()
-    ident, meta = r.resolve(cls, namespace=namespace, kind=kind, name=name, context=context)
+    ident, meta = r.resolve(
+        cls,
+        domain=domain,
+        namespace=namespace,
+        group=group,
+        name=name,
+        context=context,
+    )
     return ident, meta


### PR DESCRIPTION
## Summary
- add a canonical domain normalization helper and route IdentityResolver through decorator-aware defaults
- propagate default identity hints through core and Django decorators while keeping tuple4 helpers aligned with 4-part identities
- add coverage for domain precedence and tuple helpers in the identity test suite

## Testing
- uv run pytest packages/orchestrai
- uv run pytest packages/orchestrai_django (no tests discovered)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943169af3148333a96fef14a0cf7efc)