### PR TITLE
Add identity domain constants and validation

### DIFF
--- a/packages/orchestrai/docs/full_documentation.md
+++ b/packages/orchestrai/docs/full_documentation.md
@@ -125,6 +125,19 @@ The defaults already scan `orchestrai.contrib.provider_backends` and
 
 If you need custom behavior, point `LOADER` to your own loader class implementing `autodiscover(app, modules)`.
 
+## Identity domains
+
+OrchestrAI core ships with a small, validated set of identity domains exported from `orchestrai.identity.domains`:
+
+- `services`
+- `codecs`
+- `prompt-sections`
+- `schemas`
+- `provider-backends`
+- `providers`
+
+`normalize_domain()` collapses dots/underscores/hyphens/spaces into a single hyphen, lowercases the result, and raises a `ValueError` if the normalized value is not in the supported set. Decorators and resolvers default to the `DEFAULT_DOMAIN` constant (`services`) and validate any explicit `domain` argument before constructing an `Identity`.
+
 ## Tracing
 
 The core ships with lightweight span helpers in `orchestrai.tracing.tracing` that collect attributes without external dependencies. Integrations can wrap these spans to feed real tracing backends.

--- a/packages/orchestrai/src/orchestrai/decorators/base.py
+++ b/packages/orchestrai/src/orchestrai/decorators/base.py
@@ -36,7 +36,7 @@ from typing import Any, Optional, Type, TypeVar, Callable, cast
 
 from orchestrai.tracing import service_span_sync
 from orchestrai.identity import Identity
-from orchestrai.identity.constants import DEFAULT_DOMAIN
+from orchestrai.identity.domains import DEFAULT_DOMAIN
 from orchestrai.identity.resolvers import IdentityResolver
 
 logger = logging.getLogger(__name__)

--- a/packages/orchestrai/src/orchestrai/identity/__init__.py
+++ b/packages/orchestrai/src/orchestrai/identity/__init__.py
@@ -14,6 +14,17 @@ from .mixins import IdentityMixin
 from .resolvers import Resolve as _Resolve, IdentityResolver, resolve_identity
 from .protocols import IdentityResolverProtocol, IdentityProtocol
 from .utils import DEFAULT_IDENTITY_STRIP_TOKENS, coerce_identity_key
+from .domains import (
+    DEFAULT_DOMAIN,
+    SUPPORTED_DOMAINS,
+    SERVICES_DOMAIN,
+    CODECS_DOMAIN,
+    PROMPT_SECTIONS_DOMAIN,
+    SCHEMAS_DOMAIN,
+    PROVIDER_BACKENDS_DOMAIN,
+    PROVIDERS_DOMAIN,
+    normalize_domain,
+)
 
 # Ergonomic namespace without coupling the dataclass to registries:
 Identity.resolve = _Resolve  # type: ignore[attr-defined]
@@ -23,6 +34,15 @@ __all__ = [
     "Identity", "IdentityLike", "IdentityResolver",
     # Constants
     "DEFAULT_IDENTITY_STRIP_TOKENS",
+    "DEFAULT_DOMAIN",
+    "SUPPORTED_DOMAINS",
+    "SERVICES_DOMAIN",
+    "CODECS_DOMAIN",
+    "PROMPT_SECTIONS_DOMAIN",
+    "SCHEMAS_DOMAIN",
+    "PROVIDER_BACKENDS_DOMAIN",
+    "PROVIDERS_DOMAIN",
+    "normalize_domain",
     # Helpers
     "coerce_identity_key",
     # Protocols

--- a/packages/orchestrai/src/orchestrai/identity/constants.py
+++ b/packages/orchestrai/src/orchestrai/identity/constants.py
@@ -1,30 +1,9 @@
-"""Canonical identity constants shared across the identity layer."""
+"""Canonical identity constants shared across the identity layer.
 
-import re
-from typing import Optional
+This module is retained for backward compatibility; new code should import
+from ``orchestrai.identity.domains`` instead.
+"""
+
+from .domains import DEFAULT_DOMAIN, normalize_domain  # noqa: F401
 
 __all__ = ["DEFAULT_DOMAIN", "normalize_domain"]
-
-DEFAULT_DOMAIN = "default"
-
-
-def normalize_domain(value: Optional[str], *, default: str | None = DEFAULT_DOMAIN) -> str:
-    """Normalize a domain value, applying a canonical default when missing.
-
-    Normalization collapses dots/underscores/hyphens/spaces into single hyphens,
-    lowercases the result, and trims edges. A ``ValueError`` is raised if no
-    usable value is provided and no ``default`` is supplied.
-    """
-    candidate = value if value is not None else default
-    if candidate is None:
-        raise ValueError("domain is required")
-    if not isinstance(candidate, str):
-        raise TypeError(f"domain must be a string (got {type(candidate)!r})")
-
-    normalized = re.sub(r"[._\\s\-]+", "-", candidate.strip())
-    normalized = re.sub(r"-{2,}", "-", normalized).strip("-").lower()
-    if not normalized:
-        if default is None:
-            raise ValueError("domain cannot be empty")
-        return normalize_domain(default, default=None)
-    return normalized

--- a/packages/orchestrai/src/orchestrai/identity/domains.py
+++ b/packages/orchestrai/src/orchestrai/identity/domains.py
@@ -1,0 +1,69 @@
+"""Identity domain constants and normalization helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Optional, Sequence
+
+__all__ = [
+    "SERVICES_DOMAIN",
+    "CODECS_DOMAIN",
+    "PROMPT_SECTIONS_DOMAIN",
+    "SCHEMAS_DOMAIN",
+    "PROVIDER_BACKENDS_DOMAIN",
+    "PROVIDERS_DOMAIN",
+    "SUPPORTED_DOMAINS",
+    "DEFAULT_DOMAIN",
+    "normalize_domain",
+]
+
+SERVICES_DOMAIN = "services"
+CODECS_DOMAIN = "codecs"
+PROMPT_SECTIONS_DOMAIN = "prompt-sections"
+SCHEMAS_DOMAIN = "schemas"
+PROVIDER_BACKENDS_DOMAIN = "provider-backends"
+PROVIDERS_DOMAIN = "providers"
+
+# Canonical defaults & supported set
+DEFAULT_DOMAIN = SERVICES_DOMAIN
+SUPPORTED_DOMAINS: tuple[str, ...] = (
+    SERVICES_DOMAIN,
+    CODECS_DOMAIN,
+    PROMPT_SECTIONS_DOMAIN,
+    SCHEMAS_DOMAIN,
+    PROVIDER_BACKENDS_DOMAIN,
+    PROVIDERS_DOMAIN,
+)
+
+
+def _normalize(value: str) -> str:
+    normalized = re.sub(r"[._\s\-]+", "-", value.strip())
+    normalized = re.sub(r"-{2,}", "-", normalized).strip("-").lower()
+    if not normalized:
+        raise ValueError("domain cannot be empty")
+    return normalized
+
+
+def normalize_domain(
+    value: Optional[str],
+    *,
+    default: str | None = DEFAULT_DOMAIN,
+    allowed: Sequence[str] | None = SUPPORTED_DOMAINS,
+    extras: Iterable[str] | None = None,
+) -> str:
+    """Normalize a domain value and enforce membership in the supported set."""
+    candidate = value if value is not None else default
+    if candidate is None:
+        raise ValueError("domain is required")
+    if not isinstance(candidate, str):
+        raise TypeError(f"domain must be a string (got {type(candidate)!r})")
+
+    normalized = _normalize(candidate)
+    if allowed is not None or extras:
+        allowed_norm = {_normalize(v) for v in (allowed or ())}
+        allowed_norm.update({_normalize(v) for v in (extras or ())})
+        if normalized not in allowed_norm:
+            supported = ", ".join(sorted(allowed_norm))
+            raise ValueError(f"unsupported domain {candidate!r}; supported domains: {supported}")
+
+    return normalized

--- a/packages/orchestrai/src/orchestrai/identity/resolvers.py
+++ b/packages/orchestrai/src/orchestrai/identity/resolvers.py
@@ -40,7 +40,7 @@ from typing import Iterable, Optional, Any, TypeVar
 
 from . import registry_resolvers as _rr
 from .identity import Identity, IdentityLike
-from .constants import DEFAULT_DOMAIN, normalize_domain
+from .domains import DEFAULT_DOMAIN, normalize_domain
 from .utils import module_root, get_effective_strip_tokens, snake
 from ..types.protocols import RegistryProtocol
 

--- a/packages/orchestrai/tests/test_identity_core.py
+++ b/packages/orchestrai/tests/test_identity_core.py
@@ -1,6 +1,7 @@
 import pytest
 
 from orchestrai.identity import Identity, IdentityResolver
+from orchestrai.identity.domains import SERVICES_DOMAIN, normalize_domain
 
 
 def test_domain_precedence_and_normalization_default_context():
@@ -9,9 +10,9 @@ def test_domain_precedence_and_normalization_default_context():
         group = "Group"
         name = "ExplicitName"
 
-    ident, meta = IdentityResolver().resolve(Demo, context={"default_domain": "SIM.Core"})
+    ident, meta = IdentityResolver().resolve(Demo, context={"default_domain": " SERVICES "})
 
-    assert ident.domain == "sim-core"
+    assert ident.domain == SERVICES_DOMAIN
     assert meta["simcore.identity.source.domain"] == "default"
     assert ident.namespace == "demo_space"
     assert ident.group == "group"
@@ -22,8 +23,8 @@ def test_domain_precedence_and_normalization_default_context():
 @pytest.mark.parametrize(
     "domain_arg, domain_attr, expected, source",
     [
-        ("Explicit", "AttrDomain", "explicit", "arg"),
-        (None, "AttrDomain", "attrdomain", "attr"),
+        ("Provider Backends", "AttrDomain", "provider-backends", "arg"),
+        (None, "CODECS", "codecs", "attr"),
     ],
 )
 def test_domain_arg_overrides_and_attr_precedence(domain_arg, domain_attr, expected, source):
@@ -36,6 +37,17 @@ def test_domain_arg_overrides_and_attr_precedence(domain_arg, domain_attr, expec
 
     assert ident.domain == expected
     assert meta["simcore.identity.source.domain"] == source
+
+
+def test_normalize_domain_supported_and_rejected():
+    assert normalize_domain("prompt_sections") == "prompt-sections"
+    assert normalize_domain("schemas") == "schemas"
+
+    with pytest.raises(ValueError):
+        normalize_domain("unknown-domain")
+
+    with pytest.raises(ValueError):
+        normalize_domain(None, default=None)
 
 
 def test_resolve_facade_tuple_helpers_are_four_part_only():

--- a/packages/orchestrai/tests/test_resolvers.py
+++ b/packages/orchestrai/tests/test_resolvers.py
@@ -6,6 +6,7 @@ from orchestrai.components.promptkit import PromptPlan, PromptSection
 from orchestrai.components.schemas import BaseOutputSchema
 from orchestrai.contrib.provider_backends.openai.schema_adapters import OpenaiWrapper
 from orchestrai.identity import Identity
+from orchestrai.identity.domains import SERVICES_DOMAIN
 from orchestrai.registry import ComponentStore
 from orchestrai.registry.records import RegistrationRecord
 from orchestrai.registry.active_app import set_active_registry_app
@@ -13,7 +14,7 @@ from orchestrai.resolve import resolve_codec, resolve_prompt_plan, resolve_schem
 from orchestrai.components.services.service import BaseService
 
 
-DOMAIN = "demo"
+DOMAIN = SERVICES_DOMAIN
 
 
 class DemoSchema(BaseOutputSchema):


### PR DESCRIPTION
## Summary
- add centralized identity domain constants and validation helper for normalized domains
- update identity resolution and decorators to default to validated domains and expose the new exports
- document the supported domains and extend identity tests to cover normalization and failures

## Testing
- uv run pytest packages/orchestrai

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69431be6b9d083338ae0451299dcbe14)