### PR TITLE
Add domain-aware identity handling to decorators

### DIFF
--- a/packages/orchestrai/src/orchestrai/decorators/components/codec_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/codec_decorator.py
@@ -2,7 +2,7 @@
 """
 Core codec decorator.
 
-- Derives & pins identity via IdentityResolver (kind/namespace/name via resolver + hints).
+- Derives & pins identity via IdentityResolver (domain/namespace/group/name via resolver + hints).
 - Registers codec classes in the global `codecs` registry.
 - Preserves the `.identity` descriptor from `IdentityMixin` (pinning only, no attr overwrites).
 - Enforces that only BaseCodec subclasses can be decorated.
@@ -12,6 +12,7 @@ from typing import Any, Type
 
 from orchestrai.components.codecs.codec import BaseCodec
 from orchestrai.decorators.base import BaseDecorator
+from orchestrai.identity.domains import CODECS_DOMAIN
 from orchestrai.registry import ComponentRegistry
 from orchestrai.registry import codecs as codec_registry
 
@@ -33,10 +34,12 @@ class CodecDecorator(BaseDecorator):
             ...
 
         # or with explicit hints
-        @codec(namespace="openai", kind="responses", name="json")
+        @codec(namespace="openai", group="responses", name="json")
         class OpenAIJSONCodec(BaseCodec):
             ...
     """
+
+    default_domain = CODECS_DOMAIN
 
     def get_registry(self) -> ComponentRegistry:
         """Return the global codecs registry singleton."""

--- a/packages/orchestrai/src/orchestrai/decorators/components/prompt_section_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/prompt_section_decorator.py
@@ -1,9 +1,9 @@
 # orchestrai/decorators/components/prompt_section_decorator.py
 """
-Core codec decorator.
+Core prompt section decorator.
 
-- Derives & pins identity via IdentityResolver (kind defaults to "codec" if not provided).
-- Registers the class in the global `codecs` registry.
+- Derives & pins identity via IdentityResolver (domain/namespace/group/name via resolver + hints).
+- Registers the class in the global `prompt_sections` registry.
 - Preserves the `.identity` descriptor from `IdentityMixin` (pinning only, no attr overwrites).
 """
 
@@ -12,6 +12,7 @@ from typing import Any, Type
 
 from orchestrai.components.promptkit import PromptSection
 from orchestrai.decorators.base import BaseDecorator
+from orchestrai.identity.domains import PROMPT_SECTIONS_DOMAIN
 from orchestrai.registry import prompt_sections as _Registry
 from orchestrai.registry.base import ComponentRegistry
 
@@ -22,7 +23,7 @@ __all__ = ("PromptSectionDecorator",)
 
 class PromptSectionDecorator(BaseDecorator):
     """
-    Codec decorator specialized for DjangoPromptSectionDecorator subclasses.
+    Prompt section decorator specialized for PromptSection subclasses.
 
     Usage
     -----
@@ -33,10 +34,12 @@ class PromptSectionDecorator(BaseDecorator):
             ...
 
         # or with explicit hints
-        @prompt_section(namespace="simcore", name="my_section")
+        @prompt_section(namespace="simcore", group="sections", name="my_section")
         class MyPromptSection(PromptSection):
             ...
     """
+
+    default_domain = PROMPT_SECTIONS_DOMAIN
 
     def get_registry(self) -> ComponentRegistry:
         return _Registry

--- a/packages/orchestrai/src/orchestrai/decorators/components/provider_decorators.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/provider_decorators.py
@@ -4,7 +4,7 @@ Core provider decorators.
 
 This module defines two decorators: one for Provider Backends, and one for Provider instances.
 
-- Derive & pin identity via IdentityResolver (kind/namespace/name via resolver + hints).
+- Derive & pin identity via IdentityResolver (domain/namespace/group/name via resolver + hints).
 - Register provider backend classes in the global `provider_backends` registry.
 - Register provider “wiring” classes in the global `providers` registry.
 - Preserve the `.identity` descriptor from `IdentityMixin` (pinning only, no attr overwrites).
@@ -15,6 +15,10 @@ from typing import Any, Type
 
 from orchestrai.components.providerkit import BaseProvider
 from orchestrai.decorators.base import BaseDecorator
+from orchestrai.identity.domains import (
+    PROVIDER_BACKENDS_DOMAIN,
+    PROVIDERS_DOMAIN,
+)
 from orchestrai.registry import ComponentRegistry
 from orchestrai.registry import (
     provider_backends as provider_backend_registry,
@@ -39,10 +43,12 @@ class ProviderBackendDecorator(BaseDecorator):
             ...
 
         # or with explicit hints (for a backend, name should be "backend")
-        @backend(namespace="openai", kind="responses", name="backend")
+        @backend(namespace="openai", group="responses", name="backend")
         class OpenAiResponsesBackend(BaseProvider):
             ...
     """
+
+    default_domain = PROVIDER_BACKENDS_DOMAIN
 
     def get_registry(self) -> ComponentRegistry:
         """Return the global provider backends registry singleton (identity-keyed)."""
@@ -76,10 +82,12 @@ class ProviderDecorator(BaseDecorator):
             ...
 
         # or with explicit hints (name corresponds to the provider profile, e.g. "default" or "prod")
-        @provider(namespace="openai", kind="responses", name="prod")
+        @provider(namespace="openai", group="responses", name="prod")
         class OpenAiResponsesProvider(BaseProvider):
             ...
     """
+
+    default_domain = PROVIDERS_DOMAIN
 
     def get_registry(self) -> ComponentRegistry:
         """Return the global providers registry singleton (identity-keyed)."""

--- a/packages/orchestrai/src/orchestrai/decorators/components/schema_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/schema_decorator.py
@@ -1,11 +1,8 @@
-from orchestrai.decorators.components import PromptSectionDecorator
-from orchestrai.registry import ComponentRegistry
-
 """
-Core codec decorator.
+Core schema decorator.
 
-- Derives & pins identity via IdentityResolver (kind defaults to "codec" if not provided).
-- Registers the class in the global `codecs` registry.
+- Derives & pins identity via IdentityResolver (domain/namespace/group/name via resolver + hints).
+- Registers the class in the global `schemas` registry.
 - Preserves the `.identity` descriptor from `IdentityMixin` (pinning only, no attr overwrites).
 """
 
@@ -14,11 +11,13 @@ import logging
 
 from orchestrai.decorators.base import BaseDecorator
 from orchestrai.components.schemas import BaseOutputSchema
+from orchestrai.identity.domains import SCHEMAS_DOMAIN
+from orchestrai.registry import ComponentRegistry
 from orchestrai.registry import schemas as schema_registry
 
 logger = logging.getLogger(__name__)
 
-__all__ = ("PromptSectionDecorator",)
+__all__ = ("SchemaDecorator",)
 
 T = TypeVar("T", bound=Type[Any])
 
@@ -36,10 +35,12 @@ class SchemaDecorator(BaseDecorator):
             ...
 
         # or with explicit hints
-        @schema(namespace="simcore", name="my_schema")
+        @schema(namespace="simcore", group="schemas", name="my_schema")
         class MySchema(BaseOutputSchema):
             ...
     """
+
+    default_domain = SCHEMAS_DOMAIN
 
     def get_registry(self) -> ComponentRegistry:
         # Always register into the schema registry

--- a/packages/orchestrai/src/orchestrai/decorators/components/service_decorator.py
+++ b/packages/orchestrai/src/orchestrai/decorators/components/service_decorator.py
@@ -2,7 +2,7 @@
 """
 Core service decorator.
 
-- Derives & pins identity via IdentityResolver (kind defaults to "service" if not provided).
+- Derives & pins identity via IdentityResolver (group defaults handled by resolver).
 - Registers the class in the global `services` registry.
 - Preserves the `.identity` descriptor from `IdentityMixin` (pinning only, no attr overwrites).
 """
@@ -12,6 +12,7 @@ from typing import Any, Type
 
 from orchestrai.components.services.service import BaseService
 from orchestrai.decorators.base import BaseDecorator
+from orchestrai.identity.domains import SERVICES_DOMAIN
 from orchestrai.registry import ComponentRegistry
 from orchestrai.registry import services as services_registry
 
@@ -37,6 +38,8 @@ class ServiceDecorator(BaseDecorator):
         class MyService(BaseService):
             ...
     """
+
+    default_domain = SERVICES_DOMAIN
 
     def get_registry(self) -> ComponentRegistry:
         # Always register into the service registry

--- a/packages/orchestrai_django/src/orchestrai_django/decorators.py
+++ b/packages/orchestrai_django/src/orchestrai_django/decorators.py
@@ -4,12 +4,13 @@
 Django-aware public decorators for OrchestrAI.
 
 This module mirrors the core OrchestrAI decorator surface (codec, service, schema,
-prompt_section) but derives identities using Django context.
+prompt_section, provider, provider_backend) but derives identities using Django context.
 
-Implementation notes
---------------------
-- We reuse the core *domain* decorators (CodecDecorator, ServiceDecorator, SchemaDecorator,
-  PromptSectionDecorator) so we keep the same registry selection, type guards, and logging.
+Identity behavior
+-----------------
+- Identities are 4-part labels (domain.namespace.group.name). Django decorators honor the
+  same precedence as core (arg → class attr → decorator defaults → derived fallbacks) while
+  relying on Django-aware namespace/token inference.
 - The only Django-specific behavior is identity derivation: a small mixin overrides
   ``derive_identity`` to call :class:`~orchestrai_django.identity.resolvers.DjangoIdentityResolver`.
 - The mixin is placed first in the MRO to ensure Django identity derivation wins.
@@ -17,12 +18,15 @@ Implementation notes
 This module is intentionally side-effect free (no autodiscovery/autostart).
 """
 
-from orchestrai.decorators import provider, provider_backend
 from orchestrai.decorators.components.codec_decorator import CodecDecorator
 from orchestrai.decorators.components.prompt_section_decorator import PromptSectionDecorator
+from orchestrai.decorators.components.provider_decorators import (
+    ProviderBackendDecorator,
+    ProviderDecorator,
+)
 from orchestrai.decorators.components.schema_decorator import SchemaDecorator
 from orchestrai.decorators.components.service_decorator import ServiceDecorator
-from orchestrai.identity.constants import DEFAULT_DOMAIN
+from orchestrai.identity.domains import DEFAULT_DOMAIN
 from orchestrai_django.identity.resolvers import DjangoIdentityResolver
 
 __all__ = [
@@ -32,6 +36,12 @@ __all__ = [
     "prompt_section",
     "provider",
     "provider_backend",
+    "DjangoCodecDecorator",
+    "DjangoServiceDecorator",
+    "DjangoSchemaDecorator",
+    "DjangoPromptSectionDecorator",
+    "DjangoProviderDecorator",
+    "DjangoProviderBackendDecorator",
 ]
 
 
@@ -87,7 +97,17 @@ class DjangoServiceDecorator(DjangoBaseDecoratorMixin, ServiceDecorator):
     """Django-aware service decorator (core behavior + Django identity)."""
 
 
+class DjangoProviderDecorator(DjangoBaseDecoratorMixin, ProviderDecorator):
+    """Django-aware provider decorator (core behavior + Django identity)."""
+
+
+class DjangoProviderBackendDecorator(DjangoBaseDecoratorMixin, ProviderBackendDecorator):
+    """Django-aware provider backend decorator (core behavior + Django identity)."""
+
+
 codec = DjangoCodecDecorator()
 service = DjangoServiceDecorator()
 schema = DjangoSchemaDecorator()
 prompt_section = DjangoPromptSectionDecorator()
+provider = DjangoProviderDecorator()
+provider_backend = DjangoProviderBackendDecorator()

--- a/packages/orchestrai_django/src/orchestrai_django/identity/mixins.py
+++ b/packages/orchestrai_django/src/orchestrai_django/identity/mixins.py
@@ -21,13 +21,36 @@ class DjangoIdentityMixin(IdentityMixin):
 
     Behavior is identical to `IdentityMixin` except it uses `DjangoIdentityResolver`
     to infer namespace (preferring AppConfig.label when not explicitly provided)
-    and to collect Django-specific strip tokens during name derivation.
-
-    Class hints `namespace`, `kind`, and `name` remain optional and are consumed
-    by the resolver according to precedence rules.
+    and to collect Django-specific strip tokens during name derivation. Class hints
+    `domain`, `namespace`, `group`, and `name` remain optional and are consumed
+    by the resolver according to precedence rules (no legacy ``kind`` fallback).
     """
 
     # Use the Django resolver for all subclasses that include this mixin
     identity_resolver_cls = DjangoIdentityResolver
+
+    @classmethod
+    def resolve_identity(cls) -> "Identity":
+        """Resolve and cache identity using the Django resolver without `kind` fallback."""
+        cached = cls._IdentityMixin__identity_cached  # type: ignore[attr-defined]
+        if cached is not None:
+            return cached
+
+        from orchestrai_django.identity.resolvers import resolve_identity_django
+
+        with cls._IdentityMixin__identity_lock:  # type: ignore[attr-defined]
+            if cls._IdentityMixin__identity_cached is not None:  # type: ignore[attr-defined]
+                return cls._IdentityMixin__identity_cached  # type: ignore[attr-defined]
+
+            hints = dict(
+                domain=getattr(cls, "domain", None),
+                namespace=getattr(cls, "namespace", None),
+                group=getattr(cls, "group", None),
+                name=getattr(cls, "name", None),
+            )
+            ident, meta = resolve_identity_django(cls, **hints, context=None)
+            cls._IdentityMixin__identity_cached = ident  # type: ignore[attr-defined]
+            cls._IdentityMixin__identity_meta_cached = dict(meta or {})  # type: ignore[attr-defined]
+            return ident
 
 __all__ = ["DjangoIdentityMixin"]

--- a/packages/orchestrai_django/src/orchestrai_django/identity/resolvers.py
+++ b/packages/orchestrai_django/src/orchestrai_django/identity/resolvers.py
@@ -2,7 +2,9 @@
 Django-aware identity resolver.
 
 Subclass of the core IdentityResolver that:
-- infers `namespace` from (arg → class attr → Django app label → module root → "default"),
+- infers `namespace` from (arg → class attr → decorator default → Django app label → module root → "default"),
+- honors `domain` precedence from the core resolver (arg → class attr → decorator default → error),
+- resolves `group` without legacy ``kind`` fallbacks (arg → class attr → decorator default → "default"),
 - collects strip tokens from core defaults + Django sources:
   * DJANGO_BASE_STRIP_TOKENS = ("Django", "Mixin")
   * settings.ORCA_IDENTITY_STRIP_TOKENS (list/tuple/CSV) (SIMCORE_* accepted for back-compat)
@@ -29,7 +31,6 @@ if TYPE_CHECKING:  # type-only import to avoid runtime cycles
 __all__ = [
     "DjangoIdentityResolver",
     "resolve_identity_django",
-        "q  a",
 ]
 
 
@@ -140,6 +141,7 @@ class DjangoIdentityResolver(IdentityResolver):
             cls: type,
             namespace_arg: Optional[str],
             namespace_attr: Optional[str],
+            decorator_default: Optional[str] = None,
     ) -> tuple[str, str]:
         # arg wins
         if isinstance(namespace_arg, str) and namespace_arg.strip():
@@ -147,6 +149,9 @@ class DjangoIdentityResolver(IdentityResolver):
         # class attr next
         if isinstance(namespace_attr, str) and namespace_attr.strip():
             return namespace_attr.strip(), "attr"
+        # decorator default
+        if isinstance(decorator_default, str) and decorator_default.strip():
+            return decorator_default.strip(), "default"
         # Django app label
         cfg = _app_config_for_class(cls)
         if cfg is not None and getattr(cfg, "label", None):
@@ -154,6 +159,23 @@ class DjangoIdentityResolver(IdentityResolver):
         # fallback to module root, then default (the base will snake-case)
         root = module_root(cls) or "default"
         return root, "derived"
+
+    def _resolve_group(
+            self,
+            cls: type,
+            group_arg: Optional[str],
+            group_attr: Optional[str],
+            legacy_kind_attr: Optional[str],
+            decorator_default: Optional[str] = None,
+    ) -> tuple[str, str]:
+        """Return (value, source) without legacy `kind` fallbacks."""
+        if isinstance(group_arg, str) and group_arg.strip():
+            return group_arg.strip(), "arg"
+        if isinstance(group_attr, str) and group_attr.strip():
+            return group_attr.strip(), "attr"
+        if isinstance(decorator_default, str) and decorator_default.strip():
+            return decorator_default.strip(), "default"
+        return "default", "derived"
 
     def _collect_strip_tokens(self, cls: type) -> tuple[str, ...]:
         extra: list[str] = []


### PR DESCRIPTION
## Summary
- add domain-aware identity metadata and 4-part trace labeling in the core decorator base
- default component decorators to their identity domains while shifting docs/examples to group terminology
- expand Django decorators, mixins, and resolver hooks to honor domain/group precedence without legacy kind fallbacks

## Testing
- uv run pytest packages/orchestrai packages/orchestrai_django

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694320004a8c8333be6fb09dcaf97df1)