### PR TITLE
Route registries by identity domain

### DIFF
--- a/packages/orchestrai/src/orchestrai/identity/registry_resolvers.py
+++ b/packages/orchestrai/src/orchestrai/identity/registry_resolvers.py
@@ -26,7 +26,7 @@ def label(ident: IdentityLike) -> str:
 
 
 def tuple4(ident: IdentityLike) -> tuple[str, str, str, str]:
-    return Identity.get_for(ident).as_tuple
+    return Identity.get_for(ident).as_tuple4
 
 
 def from_(ident: IdentityLike) -> Identity:

--- a/packages/orchestrai/src/orchestrai/registry/base.py
+++ b/packages/orchestrai/src/orchestrai/registry/base.py
@@ -37,13 +37,14 @@ class BaseRegistry(Generic[K, T]):
                 if existing is cls:
                     raise RegistryDuplicateError(f"Component already registered: {key}")
 
+                key_label = getattr(key, "as_str", None) or str(key)
                 existing_fqcn = f"{existing.__module__}.{existing.__name__}"
                 candidate_fqcn = f"{cls.__module__}.{cls.__name__}"
 
                 raise RegistryCollisionError(
                     "Key already registered to different instance: {key} "
                     "(existing={existing_fqcn}, candidate={candidate_fqcn})".format(
-                        key=key,
+                        key=key_label,
                         existing_fqcn=existing_fqcn,
                         candidate_fqcn=candidate_fqcn,
                     )

--- a/packages/orchestrai/src/orchestrai/registry/component_store.py
+++ b/packages/orchestrai/src/orchestrai/registry/component_store.py
@@ -8,16 +8,16 @@ from .records import RegistrationRecord
 
 
 class ComponentStore:
-    """Container managing component registries by kind."""
+    """Container managing component registries by domain."""
 
     def __init__(self) -> None:
         self._registries: dict[str, ComponentRegistry[Any]] = {}
         self._lock = RLock()
 
-    def registry(self, kind: str) -> ComponentRegistry[Any]:
-        key = str(kind).strip()
+    def registry(self, domain: str) -> ComponentRegistry[Any]:
+        key = str(domain).strip()
         if not key:
-            raise ValueError("registry kind must be a non-empty string")
+            raise ValueError("registry domain must be a non-empty string")
 
         with self._lock:
             if key not in self._registries:
@@ -25,22 +25,26 @@ class ComponentStore:
             return self._registries[key]
 
     def register(self, record: RegistrationRecord) -> None:
-        registry = self.registry(record.kind)
+        registry = self.registry(record.domain)
         registry.register(record.component)
 
-    def try_get(self, kind: str, ident: Any):
-        return self.registry(kind).try_get(ident)
+    def try_get(self, domain: str, ident: Any):
+        return self.registry(domain).try_get(ident)
 
-    def get(self, kind: str, ident: Any):
-        return self.registry(kind).get(ident)
+    def get(self, domain: str, ident: Any):
+        return self.registry(domain).get(ident)
 
     def items(self) -> dict[str, ComponentRegistry[Any]]:
         with self._lock:
             return dict(self._registries)
 
-    def kinds(self) -> tuple[str, ...]:
+    def domains(self) -> tuple[str, ...]:
         with self._lock:
             return tuple(sorted(self._registries.keys()))
+
+    # Backward-compatible alias
+    def kinds(self) -> tuple[str, ...]:
+        return self.domains()
 
     def freeze_all(self) -> None:
         for registry in self.items().values():

--- a/packages/orchestrai/src/orchestrai/registry/records.py
+++ b/packages/orchestrai/src/orchestrai/registry/records.py
@@ -28,7 +28,11 @@ class RegistrationRecord:
 
     @property
     def kind(self) -> str:
-        return self.identity.group
+        return self.domain
+
+    @property
+    def domain(self) -> str:
+        return self.identity.domain
 
     @property
     def label(self) -> str:

--- a/packages/orchestrai/src/orchestrai/resolve/codec.py
+++ b/packages/orchestrai/src/orchestrai/resolve/codec.py
@@ -6,6 +6,7 @@ import logging
 from typing import Iterable
 
 from orchestrai.components.codecs import BaseCodec
+from orchestrai.identity.domains import CODECS_DOMAIN
 
 from .result import ResolutionBranch, ResolutionResult
 
@@ -93,9 +94,9 @@ def resolve_codec(
     registry_candidates: list[type[BaseCodec]] = []
     if store is not None and constraints:
         try:
-            registry = store.registry("codec")
+            registry = store.registry(CODECS_DOMAIN)
             for cand in registry.items():
-                if _matches_constraints(cand, constraints):
+                if issubclass(cand, BaseCodec) and _matches_constraints(cand, constraints):
                     registry_candidates.append(cand)
         except Exception:
             logger.debug("codec resolution: registry lookup failed", exc_info=True)

--- a/packages/orchestrai/src/orchestrai/resolve/prompt_plan.py
+++ b/packages/orchestrai/src/orchestrai/resolve/prompt_plan.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 from orchestrai.components.promptkit import PromptPlan, PromptSection
 from orchestrai.identity import Identity
+from orchestrai.identity.domains import PROMPT_SECTIONS_DOMAIN
 
 from .result import ResolutionBranch, ResolutionResult
 
@@ -44,16 +45,16 @@ def resolve_prompt_plan(service) -> ResolutionResult[PromptPlan | None]:
     # Registry match: prompt section whose identity matches the service
     section_cls = None
     if store is not None:
-        lookup_ident = getattr(service, "identity", None)
-        if isinstance(lookup_ident, Identity):
+        lookup_ident = Identity.try_get(getattr(service, "identity", None))
+        if lookup_ident is not None:
             lookup_ident = Identity(
-                domain=lookup_ident.domain,
+                domain=PROMPT_SECTIONS_DOMAIN,
                 namespace=lookup_ident.namespace,
                 group="prompt_section",
                 name=lookup_ident.name,
             )
         try:
-            section_cls = store.try_get("prompt_section", lookup_ident or service.identity)
+            section_cls = store.try_get(PROMPT_SECTIONS_DOMAIN, lookup_ident or service.identity)
         except Exception:  # pragma: no cover - defensive
             logger.debug("prompt plan resolution: prompt_section lookup failed", exc_info=True)
 

--- a/packages/orchestrai/src/orchestrai/resolve/schema.py
+++ b/packages/orchestrai/src/orchestrai/resolve/schema.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 from orchestrai.components.schemas import BaseOutputSchema, sort_adapters
 from orchestrai.identity import Identity
+from orchestrai.identity.domains import SCHEMAS_DOMAIN
 
 from .result import ResolutionBranch, ResolutionResult
 
@@ -76,16 +77,16 @@ def resolve_schema(
 
     candidate = None
     if store is not None:
-        lookup_ident = identity
-        if isinstance(identity, Identity):
+        lookup_ident = Identity.try_get(identity)
+        if lookup_ident is not None:
             lookup_ident = Identity(
-                domain=identity.domain,
-                namespace=identity.namespace,
+                domain=SCHEMAS_DOMAIN,
+                namespace=lookup_ident.namespace,
                 group="schema",
-                name=identity.name,
+                name=lookup_ident.name,
             )
         try:
-            candidate = store.try_get("schema", lookup_ident)
+            candidate = store.try_get(SCHEMAS_DOMAIN, lookup_ident or identity)
         except Exception:
             logger.debug("schema resolution: ComponentStore lookup failed", exc_info=True)
 

--- a/packages/orchestrai/tests/test_resolvers.py
+++ b/packages/orchestrai/tests/test_resolvers.py
@@ -6,7 +6,12 @@ from orchestrai.components.promptkit import PromptPlan, PromptSection
 from orchestrai.components.schemas import BaseOutputSchema
 from orchestrai.contrib.provider_backends.openai.schema_adapters import OpenaiWrapper
 from orchestrai.identity import Identity
-from orchestrai.identity.domains import SERVICES_DOMAIN
+from orchestrai.identity.domains import (
+    CODECS_DOMAIN,
+    PROMPT_SECTIONS_DOMAIN,
+    SCHEMAS_DOMAIN,
+    SERVICES_DOMAIN,
+)
 from orchestrai.registry import ComponentStore
 from orchestrai.registry.records import RegistrationRecord
 from orchestrai.registry.active_app import set_active_registry_app
@@ -14,30 +19,33 @@ from orchestrai.resolve import resolve_codec, resolve_prompt_plan, resolve_schem
 from orchestrai.components.services.service import BaseService
 
 
-DOMAIN = SERVICES_DOMAIN
+SERVICE_DOMAIN = SERVICES_DOMAIN
+PROMPT_DOMAIN = PROMPT_SECTIONS_DOMAIN
+SCHEMA_DOMAIN = SCHEMAS_DOMAIN
+CODEC_DOMAIN = CODECS_DOMAIN
 
 
 class DemoSchema(BaseOutputSchema):
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="schema", name="svc")
+    identity: ClassVar[Identity] = Identity(domain=SCHEMA_DOMAIN, namespace="demo", group="schema", name="svc")
     foo: str
 
 
 class DemoPrompt(PromptSection):
     abstract = False
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="prompt_section", name="svc")
+    identity: ClassVar[Identity] = Identity(domain=PROMPT_DOMAIN, namespace="demo", group="prompt_section", name="svc")
     instruction = "hello"
     message = "world"
 
 
 class AltPrompt(PromptSection):
     abstract = False
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="prompt_section", name="alt")
+    identity: ClassVar[Identity] = Identity(domain=PROMPT_DOMAIN, namespace="demo", group="prompt_section", name="alt")
     instruction = "alt"
 
 
 class LowCodec(BaseCodec):
     abstract = False
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="codec", name="low")
+    identity: ClassVar[Identity] = Identity(domain=CODEC_DOMAIN, namespace="demo", group="codec", name="low")
     priority = 1
     response_schema = DemoSchema
 
@@ -48,7 +56,7 @@ class LowCodec(BaseCodec):
 
 class HighCodec(BaseCodec):
     abstract = False
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="codec", name="high")
+    identity: ClassVar[Identity] = Identity(domain=CODEC_DOMAIN, namespace="demo", group="codec", name="high")
     priority = 5
     response_schema = DemoSchema
 
@@ -59,7 +67,7 @@ class HighCodec(BaseCodec):
 
 class AdapterCodec(BaseCodec):
     abstract = False
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="codec", name="adapter")
+    identity: ClassVar[Identity] = Identity(domain=CODEC_DOMAIN, namespace="demo", group="codec", name="adapter")
     response_schema = DemoSchema
     schema_adapters = (OpenaiWrapper(order=0),)
 
@@ -70,7 +78,7 @@ class AdapterCodec(BaseCodec):
 
 class DemoService(BaseService):
     abstract = False
-    identity: ClassVar[Identity] = Identity(domain=DOMAIN, namespace="demo", group="service", name="svc")
+    identity: ClassVar[Identity] = Identity(domain=SERVICE_DOMAIN, namespace="demo", group="service", name="svc")
     provider_name = "demo"
 
 
@@ -113,7 +121,7 @@ def test_prompt_plan_resolution_branches(store):
 
 
 def test_schema_resolution_branches(store):
-    ident = Identity(domain=DOMAIN, namespace="demo", group="service", name="svc")
+    ident = Identity(domain=SERVICE_DOMAIN, namespace="demo", group="service", name="svc")
 
     # override wins
     res_override = resolve_schema(identity=ident, override=DemoSchema, store=store)
@@ -139,7 +147,7 @@ def test_schema_resolution_branches(store):
 
 
 def test_schema_adapter_application():
-    ident = Identity(domain=DOMAIN, namespace="demo", group="service", name="svc")
+    ident = Identity(domain=SERVICE_DOMAIN, namespace="demo", group="service", name="svc")
     res = resolve_schema(identity=ident, override=DemoSchema, adapters=AdapterCodec.schema_adapters)
     schema_json = res.selected.meta.get("schema_json")
     assert res.branch == "override"


### PR DESCRIPTION
## Summary
- route ComponentStore registries and active app proxies by identity domain and include clearer collision errors
- update registry resolver helpers and resolution flows to use domain-specific identities and 4-part labels
- refresh resolver tests to reflect domain-separated component identities

## Testing
- uv run pytest packages/orchestrai

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694337c7af988333b44da02f908b5324)