### PR TITLE
Adopt domain-prefixed identities across tests and tooling

### DIFF
--- a/SimWorks/chatlab/orca/services/patient.py
+++ b/SimWorks/chatlab/orca/services/patient.py
@@ -37,9 +37,9 @@ class GenerateInitialResponse(ChatlabMixin, StandardizedPatientMixin, DjangoBase
     #     PatientNameSection,
     # )
     prompt_plan = (
-        "chatlab.default.base",
-        "chatlab.standardized_patient.initial",
-        "simcore.standardized_patient.name",
+        "prompt-sections.chatlab.default.base",
+        "prompt-sections.chatlab.standardized_patient.initial",
+        "prompt-sections.simcore.standardized_patient.name",
     )
 
 @service

--- a/docker/scripts/build-run_service.sh
+++ b/docker/scripts/build-run_service.sh
@@ -9,8 +9,8 @@ SERVER_SERVICE="${SERVER_SERVICE:-server}"
 # Usage:
 #   ./build-run_service.sh [service_identity] [sim_context_json]
 # Example:
-#   ./build-run_service.sh chatlab.standardized_patient.initial '{"simulation_id": 1}'
-SERVICE_IDENTITY="${1:-chatlab.standardized_patient.initial}"
+#   ./build-run_service.sh services.chatlab.standardized_patient.initial '{"simulation_id": 1}'
+SERVICE_IDENTITY="${1:-services.chatlab.standardized_patient.initial}"
 SIM_CONTEXT_JSON="${2:-{\"simulation_id\": 1}}"
 
 echo ">>> Building images (no cache) using ${DEV_COMPOSE_FILE}..."

--- a/docker/scripts/build-run_service_dry.sh
+++ b/docker/scripts/build-run_service_dry.sh
@@ -17,6 +17,6 @@ docker compose -f "$COMPOSE_FILE" exec "${SERVICE_NAME}" \
 
 echo ">>> Running manage.py run_service inside ${SERVICE_NAME}..."
 docker compose -f "${COMPOSE_FILE}" exec "${SERVICE_NAME}" \
-  python manage.py run_service chatlab.standardized_patient.initial --context-json "${SIM_CONTEXT}" --dry-run
+  python manage.py run_service services.chatlab.standardized_patient.initial --context-json "${SIM_CONTEXT}" --dry-run
 
 echo ">>> Done."

--- a/packages/orchestrai/tests/test_identity_core.py
+++ b/packages/orchestrai/tests/test_identity_core.py
@@ -1,7 +1,38 @@
 import pytest
 
+from orchestrai.components.codecs import BaseCodec
+from orchestrai.components.promptkit import PromptSection
+from orchestrai.components.providerkit import BaseProvider
+from orchestrai.components.schemas import BaseOutputSchema
+from orchestrai.components.services.service import BaseService
+from orchestrai.decorators import (
+    codec,
+    prompt_section,
+    provider,
+    provider_backend,
+    schema,
+    service,
+)
+from orchestrai.decorators.components.codec_decorator import CodecDecorator
+from orchestrai.decorators.components.prompt_section_decorator import PromptSectionDecorator
+from orchestrai.decorators.components.provider_decorators import (
+    ProviderBackendDecorator,
+    ProviderDecorator,
+)
+from orchestrai.decorators.components.schema_decorator import SchemaDecorator
+from orchestrai.decorators.components.service_decorator import ServiceDecorator
 from orchestrai.identity import Identity, IdentityResolver
-from orchestrai.identity.domains import SERVICES_DOMAIN, normalize_domain
+from orchestrai.identity.domains import (
+    CODECS_DOMAIN,
+    PROMPT_SECTIONS_DOMAIN,
+    PROVIDER_BACKENDS_DOMAIN,
+    PROVIDERS_DOMAIN,
+    SCHEMAS_DOMAIN,
+    SERVICES_DOMAIN,
+    normalize_domain,
+)
+from orchestrai.registry.base import ComponentRegistry
+from orchestrai.registry.exceptions import RegistryCollisionError
 
 
 def test_domain_precedence_and_normalization_default_context():
@@ -56,3 +87,85 @@ def test_resolve_facade_tuple_helpers_are_four_part_only():
     assert Identity.resolve.as_tuple(ident) == ("d", "n", "g", "x")
     assert Identity.resolve.as_tuple4(ident) == ("d", "n", "g", "x")
     assert Identity.resolve.as_label(ident) == "d.n.g.x"
+
+
+def test_registry_collision_is_domain_sensitive_and_mentions_both_classes():
+    registry = ComponentRegistry()
+
+    class DemoService:
+        identity = Identity(domain=SERVICES_DOMAIN, namespace="demo", group="svc", name="item")
+
+    class DemoCodec:
+        identity = Identity(domain=CODECS_DOMAIN, namespace="demo", group="svc", name="item")
+
+    registry.register(DemoService)
+    registry.register(DemoCodec)
+
+    class DuplicateService:
+        identity = Identity(domain=SERVICES_DOMAIN, namespace="demo", group="svc", name="item")
+
+    with pytest.raises(RegistryCollisionError) as excinfo:
+        registry.register(DuplicateService)
+
+    message = str(excinfo.value)
+    assert "DemoService" in message
+    assert "DuplicateService" in message
+
+
+def test_decorators_apply_domain_defaults_per_component_type():
+    class NoopServiceDecorator(ServiceDecorator):
+        def register(self, candidate):  # type: ignore[override]
+            return None
+
+    class NoopCodecDecorator(CodecDecorator):
+        def register(self, candidate):  # type: ignore[override]
+            return None
+
+    class NoopSchemaDecorator(SchemaDecorator):
+        def register(self, candidate):  # type: ignore[override]
+            return None
+
+    class NoopPromptDecorator(PromptSectionDecorator):
+        def register(self, candidate):  # type: ignore[override]
+            return None
+
+    class NoopProviderDecorator(ProviderDecorator):
+        def register(self, candidate):  # type: ignore[override]
+            return None
+
+    class NoopProviderBackendDecorator(ProviderBackendDecorator):
+        def register(self, candidate):  # type: ignore[override]
+            return None
+
+    @NoopServiceDecorator()(namespace="demo", group="svc", name="svc")
+    class DemoService(BaseService):
+        abstract = False
+        provider_name = "stub"
+
+    @NoopCodecDecorator()(namespace="demo", group="codec", name="json")
+    class DemoCodec(BaseCodec):
+        abstract = False
+
+    @NoopSchemaDecorator()(namespace="demo", group="schema", name="out")
+    class DemoSchema(BaseOutputSchema):
+        val: str
+
+    @NoopPromptDecorator()(namespace="demo", group="prompt", name="section")
+    class DemoPrompt(PromptSection):
+        abstract = False
+        instruction = "hi"
+
+    @NoopProviderDecorator()(namespace="demo", group="provider", name="default")
+    class DemoProvider(BaseProvider):
+        abstract = False
+
+    @NoopProviderBackendDecorator()(namespace="demo", group="backend", name="default")
+    class DemoBackend(BaseProvider):
+        abstract = False
+
+    assert DemoService.identity.as_str == "services.demo.svc.svc"
+    assert DemoCodec.identity.as_str == "codecs.demo.codec.json"
+    assert DemoSchema.identity.as_str == "schemas.demo.schema.out"
+    assert DemoPrompt.identity.as_str == "prompt-sections.demo.prompt.section"
+    assert DemoProvider.identity.as_str == "providers.demo.provider.default"
+    assert DemoBackend.identity.as_str == "provider-backends.demo.backend.default"

--- a/packages/orchestrai_django/src/orchestrai_django/management/commands/run_service.py
+++ b/packages/orchestrai_django/src/orchestrai_django/management/commands/run_service.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "service",
             type=str,
-            help="Service registry identity (e.g. 'chatlab.standardized_patient.initial').",
+            help="Service registry identity (e.g. 'services.chatlab.standardized_patient.initial').",
         )
         parser.add_argument(
             "-c",

--- a/tests/orchestrai/test_component_reporting_and_schemas.py
+++ b/tests/orchestrai/test_component_reporting_and_schemas.py
@@ -39,7 +39,7 @@ def clear_component_registries():
 def test_decorator_logs_use_category_labels(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.INFO)
 
-    @service(namespace="log", kind="demo", name="svc")
+    @service(namespace="log", group="demo", name="svc")
     class LoggedService(BaseService):
         abstract = False
 
@@ -50,27 +50,27 @@ def test_decorator_logs_use_category_labels(caplog: pytest.LogCaptureFixture):
 
 
 def test_component_report_lists_discovered_components():
-    @service(namespace="report", kind="svc", name="demo")
+    @service(namespace="report", group="svc", name="demo")
     class ReportService(BaseService):
         abstract = False
 
         def execute(self):
             return None
 
-    @codec(namespace="report", kind="api", name="json")
+    @codec(namespace="report", group="api", name="json")
     class ReportCodec(BaseCodec):
         abstract = False
 
-    @schema(namespace="report", kind="svc", name="schema")
+    @schema(namespace="report", group="svc", name="schema")
     class ReportSchema(BaseOutputSchema):
         value: str
 
-    @prompt_section(namespace="report", kind="prompt", name="section")
+    @prompt_section(namespace="report", group="prompt", name="section")
     class ReportPrompt(PromptSection):
         abstract = False
         instruction = "demo"
 
-    @provider_backend(namespace="report", kind="api", name="backend")
+    @provider_backend(namespace="report", group="api", name="backend")
     class ReportBackend(BaseProvider):
         abstract = False
 
@@ -78,20 +78,20 @@ def test_component_report_lists_discovered_components():
     app.ensure_ready()
     report = app.component_report_text()
 
-    assert "report.svc.demo" in report
-    assert "report.api.json" in report
-    assert "report.svc.schema" in report
-    assert "report.prompt.section" in report
-    assert "report.api.backend" in report
+    assert "services.report.svc.demo" in report
+    assert "codecs.report.api.json" in report
+    assert "schemas.report.svc.schema" in report
+    assert "prompt-sections.report.prompt.section" in report
+    assert "provider-backends.report.api.backend" in report
 
 
 @pytest.mark.asyncio
 async def test_response_schema_resolves_and_attaches_request():
-    @schema(namespace="chatlab", kind="standardized_patient", name="initial")
+    @schema(namespace="chatlab", group="standardized_patient", name="initial")
     class PatientInitialSchema(BaseOutputSchema):
         value: str
 
-    @service(namespace="chatlab", kind="standardized_patient", name="initial")
+    @service(namespace="chatlab", group="standardized_patient", name="initial")
     class PatientInitialService(BaseService):
         abstract = False
         provider_name = "openai.responses"

--- a/tests/orchestrai/test_service_resolution.py
+++ b/tests/orchestrai/test_service_resolution.py
@@ -8,9 +8,10 @@ from orchestrai.client.settings_loader import ClientSettings
 from orchestrai.components.services.exceptions import ServiceConfigError
 from orchestrai.components.services.service import BaseService
 from orchestrai.decorators import service
+from orchestrai.identity.domains import SERVICES_DOMAIN
 
 
-@service(namespace="chatlab", kind="standardized_patient", name="initial")
+@service(namespace="chatlab", group="standardized_patient", name="initial")
 class RegistryService(BaseService):
     abstract = False
 
@@ -35,7 +36,7 @@ def test_service_resolution_prefers_registry(monkeypatch):
 
     def tracking_import(name, *args, **kwargs):
         calls.append(name)
-        if name == "chatlab.standardized_patient":
+        if name == "services.chatlab.standardized_patient":
             raise AssertionError("service identity should not be imported for resolution")
         return real_import(name, *args, **kwargs)
 
@@ -45,13 +46,13 @@ def test_service_resolution_prefers_registry(monkeypatch):
     app.set_as_current()
     app.ensure_ready()
 
-    resolved = app.services.get("chatlab.standardized_patient.initial")
+    resolved = app.services.get("services.chatlab.standardized_patient.initial")
     assert resolved is RegistryService
 
-    result = app.services.start("chatlab.standardized_patient.initial")
+    result = app.services.start("services.chatlab.standardized_patient.initial")
     assert result == {"status": "ok"}
 
-    assert "chatlab.standardized_patient" not in calls
+    assert "services.chatlab.standardized_patient" not in calls
 
 
 def test_service_resolution_error_points_to_single_mode(monkeypatch):


### PR DESCRIPTION
## Summary
- add coverage for domain-aware identities and decorator defaults while updating fixtures to use `group=` and four-part labels
- align Django management command helpers and signals with domain-prefixed identity handling
- update SimWorks prompt plans and helper scripts to reference four-part identity strings

## Testing
- uv run pytest packages/orchestrai/tests/test_identity_core.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433b3ca3588333b50ea15bd9044c13)