### PR TITLE
Add base protocol for service runners

### DIFF
--- a/packages/orchestrai/src/orchestrai/app.py
+++ b/packages/orchestrai/src/orchestrai/app.py
@@ -37,6 +37,7 @@ from .registry.active_app import (
     push_active_registry_app,
     set_active_registry_app,
 )
+from .service_runners import BaseServiceRunner
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +84,8 @@ class OrchestrAI:
     clients: dict[str, Any] = field(default_factory=dict)
     providers: dict[str, Any] = field(default_factory=dict)
 
-    service_runners: dict[str, Any] = field(default_factory=dict)
+    #: Registered service runner implementations keyed by name (see BaseServiceRunner).
+    service_runners: dict[str, BaseServiceRunner] = field(default_factory=dict)
     _service_finalize_callbacks: list[Callable[["OrchestrAI"], None]] = field(
         default_factory=list, repr=False
     )
@@ -243,7 +245,8 @@ class OrchestrAI:
         self._service_finalize_callbacks.append(callback)
         return callback
 
-    def register_service_runner(self, name: str, runner: Any) -> Any:
+    def register_service_runner(self, name: str, runner: BaseServiceRunner) -> BaseServiceRunner:
+        """Register a :class:`BaseServiceRunner` implementation by name."""
         if name not in self.service_runners:
             self.service_runners[name] = runner
         return runner

--- a/packages/orchestrai/src/orchestrai/service_runners/__init__.py
+++ b/packages/orchestrai/src/orchestrai/service_runners/__init__.py
@@ -1,0 +1,5 @@
+"""Interfaces for orchestrating service execution across backends."""
+
+from .base import BaseServiceRunner, TaskStatus
+
+__all__ = ["BaseServiceRunner", "TaskStatus"]

--- a/packages/orchestrai/src/orchestrai/service_runners/base.py
+++ b/packages/orchestrai/src/orchestrai/service_runners/base.py
@@ -1,0 +1,73 @@
+"""Base protocol for service runner integrations.
+
+Service runners coordinate the execution lifecycle for services, whether they
+run inline or dispatch to external systems. The protocol stays lightweight so
+it can be referenced from type hints without pulling in optional integrations
+such as Django.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover - only used for type checking
+    from orchestrai.components.services.service import BaseService
+
+
+@dataclass(slots=True)
+class TaskStatus:
+    """Status payload returned by service runners."""
+
+    id: str
+    state: str
+    result: Any | None = None
+    error: Exception | str | None = None
+
+
+@runtime_checkable
+class BaseServiceRunner(Protocol):
+    """Minimal interface runners should expose to :class:`ServiceCall`."""
+
+    def start(
+        self,
+        *,
+        service_cls: type[BaseService],
+        service_kwargs: dict[str, Any],
+        phase: str,
+        runner_kwargs: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute the service synchronously, returning a result or response."""
+
+    def enqueue(
+        self,
+        *,
+        service_cls: type[BaseService],
+        service_kwargs: dict[str, Any],
+        phase: str,
+        runner_kwargs: dict[str, Any] | None = None,
+    ) -> TaskStatus | Any:
+        """Queue the service for async execution and return task metadata."""
+
+    def stream(
+        self,
+        *,
+        service_cls: type[BaseService],
+        service_kwargs: dict[str, Any],
+        phase: str,
+        runner_kwargs: dict[str, Any] | None = None,
+    ) -> Any:
+        """Optional streaming interface for runners that support it."""
+
+    def get_status(
+        self,
+        *,
+        service_cls: type[BaseService],
+        service_kwargs: dict[str, Any],
+        phase: str,
+        runner_kwargs: dict[str, Any] | None = None,
+    ) -> TaskStatus | Any:
+        """Retrieve the latest status for an enqueued service run."""
+
+
+__all__ = ["BaseServiceRunner", "TaskStatus"]

--- a/packages/orchestrai/src/orchestrai/services/call.py
+++ b/packages/orchestrai/src/orchestrai/services/call.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field, replace
 from typing import Any, TYPE_CHECKING
 
 from orchestrai._state import get_current_app
+from orchestrai.service_runners import BaseServiceRunner
 
 if TYPE_CHECKING:  # pragma: no cover
     from orchestrai.components.services.service import BaseService
@@ -39,7 +40,7 @@ class ServiceCall:
         merged_kwargs = {**self.runner_kwargs, **runner_kwargs}
         return replace(self, runner_name=name or self.runner_name, runner_kwargs=merged_kwargs)
 
-    def _resolve_runner(self) -> tuple[str, Any]:
+    def _resolve_runner(self) -> tuple[str, BaseServiceRunner]:
         app = get_current_app()
         runners = getattr(app, "service_runners", None)
         if runners is None:


### PR DESCRIPTION
## Summary
- add a BaseServiceRunner protocol and TaskStatus dataclass for runner integrations
- expose the service runner interfaces via orchestrai.service_runners
- type-annotate service runner registration and resolution to align with the new protocol

## Testing
- uv run pytest packages/orchestrai *(fails: existing identity resolver tests expecting simcore.identity.source.domain metadata)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694446019634833380f877cd8c1f8f37)