### PR TITLE
Use enqueue for patient reply scheduling

### DIFF
--- a/SimWorks/chatlab/consumers.py
+++ b/SimWorks/chatlab/consumers.py
@@ -8,7 +8,6 @@ from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.urls import reverse
 from django.utils import timezone
-from orchestrai import get_current_app
 
 from simulation.models import Simulation
 from simulation.utils import get_user_initials
@@ -206,11 +205,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
         """Generate patient response."""
         from .orca.services import GenerateReplyResponse
 
-        await get_current_app().services.aschedule(
-            GenerateReplyResponse,
+        await GenerateReplyResponse.using(
             simulation_id=self.simulation.pk,
             user_msg_id=user_msg.pk,
-        )
+        ).enqueue()
 
 
     async def _generate_stitch_response(self, user_msg: Message) -> None:


### PR DESCRIPTION
## Summary
- replace the patient reply scheduling call to use `GenerateReplyResponse.using(...).enqueue()`
- keep async invocation while removing the direct `aschedule` dependency

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444e51cac883338385dc63df624ec5)