### PR TITLE
Restore ServiceCall task helper for runner operations

### DIFF
--- a/packages/orchestrai/src/orchestrai/components/service_runners/local.py
+++ b/packages/orchestrai/src/orchestrai/components/service_runners/local.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from typing import Any
 
 import asyncio
@@ -10,6 +11,9 @@ import asyncio
 from asgiref.sync import async_to_sync, sync_to_async
 
 from .base import register_service_runner
+
+
+logger = logging.getLogger(__name__)
 
 
 class LocalServiceRunner:

--- a/packages/orchestrai/src/orchestrai/services/call.py
+++ b/packages/orchestrai/src/orchestrai/services/call.py
@@ -39,6 +39,18 @@ class ServiceCall:
     runner_kwargs: dict[str, Any] = field(default_factory=dict)
     phase: str = "service"
 
+    @property
+    def task(self) -> "ServiceCall":
+        """Return a copy configured for runner/task execution.
+
+        This preserves backwards compatibility for workflows that call
+        ``ServiceClass.using(...).task.enqueue()``. Prefer calling
+        ``enqueue()``/``stream()``/``start()`` directly on the service call
+        when possible.
+        """
+
+        return replace(self, phase="runner")
+
     def using(self, **service_kwargs: Any) -> "ServiceCall":
         """Return a new call with updated service kwargs."""
         merged = {**self.service_kwargs, **service_kwargs}

--- a/packages/orchestrai/tests/test_service_call_api.py
+++ b/packages/orchestrai/tests/test_service_call_api.py
@@ -41,13 +41,32 @@ class UnsupportedRunner(BaseServiceRunner):
         raise NotImplementedError("status not supported")
 
 
+class TaskAwareRunner(BaseServiceRunner):
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def start(self, **payload):
+        self.calls.append(("start", payload))
+        return payload
+
+    def enqueue(self, **payload):
+        self.calls.append(("enqueue", payload))
+        return payload
+
+    def stream(self, **payload):
+        self.calls.append(("stream", payload))
+        return payload
+
+
 def test_coerce_runner_name_prefers_explicit_and_identity():
-    assert _coerce_runner_name(DemoService, explicit="custom") == "custom"
+    app = SimpleNamespace(default_service_runner=None)
+
+    assert _coerce_runner_name(app, DemoService, explicit="custom") == "custom"
 
     class NoIdentity(BaseService):
         abstract = False
 
-    assert _coerce_runner_name(NoIdentity, explicit=None) == "no-identity"
+    assert _coerce_runner_name(app, NoIdentity, explicit=None) == "no-identity"
 
 
 def test_service_call_dispatch_merges_kwargs_and_uses_phase():
@@ -74,6 +93,54 @@ def test_service_call_raises_for_unsupported_operations():
             call.stream()
         with pytest.raises(NotImplementedError):
             call.get_status()
+
+
+def test_service_call_task_property_switches_phase():
+    call = ServiceCall(
+        service_cls=DemoService,
+        service_kwargs={"foo": "bar"},
+        runner_name="demo",
+        runner_kwargs={"priority": 5},
+        phase="service",
+    )
+
+    task_call = call.task
+
+    assert task_call is not call
+    assert task_call.phase == "runner"
+    assert task_call.service_cls is call.service_cls
+    assert task_call.service_kwargs == call.service_kwargs
+    assert task_call.runner_name == call.runner_name
+    assert task_call.runner_kwargs == call.runner_kwargs
+
+
+def test_service_call_task_supports_enqueue_stream_and_start():
+    runner = TaskAwareRunner()
+    app = SimpleNamespace(service_runners={"demo": runner})
+    call = ServiceCall(
+        service_cls=DemoService,
+        service_kwargs={"foo": "bar"},
+        runner_name="demo",
+    )
+
+    with push_current_app(app):
+        task_call = call.task
+        enqueue_payload = task_call.enqueue(extra=1)
+        stream_payload = task_call.stream()
+        start_payload = task_call.start()
+
+    assert enqueue_payload["phase"] == "runner"
+    assert enqueue_payload["service_kwargs"] == {"foo": "bar", "extra": 1}
+    assert stream_payload["phase"] == "runner"
+    assert stream_payload["service_kwargs"] == {"foo": "bar"}
+    assert start_payload["phase"] == "runner"
+    assert start_payload["service_kwargs"] == {"foo": "bar"}
+
+    assert runner.calls == [
+        ("enqueue", enqueue_payload),
+        ("stream", stream_payload),
+        ("start", start_payload),
+    ]
 
 
 def test_service_task_wraps_context_and_runner_phase():


### PR DESCRIPTION
## Summary
- add a `task` property to `ServiceCall` that returns a runner-phase copy for backward-compatible task semantics
- cover the new property with regression tests for enqueue/stream/start dispatch
- fix the local service runner to log correctly when enqueueing via the task path

## Testing
- uv run pytest packages/orchestrai

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ffd590b083338ef77befaed2f3a4)