### PR TITLE
Guard against runner-style service using

### DIFF
--- a/packages/orchestrai/tests/test_service_call_api.py
+++ b/packages/orchestrai/tests/test_service_call_api.py
@@ -52,6 +52,11 @@ def test_task_using_queue_is_rejected():
         SyncTaskService.task.using(queue="hi-priority")
 
 
+def test_runner_style_using_is_blocked():
+    with pytest.raises(RuntimeError, match="task\\.using"):
+        SyncTaskService.using(queue="legacy-runner")
+
+
 def test_legacy_runner_imports_are_guarded():
     with pytest.raises(ImportError):
         importlib.import_module("orchestrai.components.services.runners")


### PR DESCRIPTION
## Summary
- remove the unused ServiceSpec-based service using helper and keep instance construction
- add a guard that raises a clear error when runner-style using arguments are passed, pointing to task.using or direct instantiation
- add coverage to confirm the legacy runner path now raises with the expected hint

## Testing
- uv run pytest packages/orchestrai


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955722042a88333abcc1f67b973a3ab)