### PR TITLE
Add runtime error shim for removed Django task service runner

### DIFF
--- a/packages/orchestrai_django/src/orchestrai_django/components/service_runners/__init__.py
+++ b/packages/orchestrai_django/src/orchestrai_django/components/service_runners/__init__.py
@@ -1,5 +1,7 @@
-"""Django-backed service runners."""
+"""Service runner shims are deprecated and raise immediately."""
 
-from .django_tasks import DjangoTaskServiceRunner
+from ._messages import REMOVED_SERVICE_RUNNER_MESSAGE
 
-__all__ = ["DjangoTaskServiceRunner"]
+raise RuntimeError(REMOVED_SERVICE_RUNNER_MESSAGE)
+
+__all__: list[str] = []

--- a/packages/orchestrai_django/src/orchestrai_django/components/service_runners/_messages.py
+++ b/packages/orchestrai_django/src/orchestrai_django/components/service_runners/_messages.py
@@ -1,0 +1,7 @@
+"""Shared messaging for removed service runner shims."""
+
+REMOVED_SERVICE_RUNNER_MESSAGE = (
+    "Service runners have been removed. Use BaseService.task.run/arun or the Django task proxy."
+)
+
+__all__ = ["REMOVED_SERVICE_RUNNER_MESSAGE"]

--- a/packages/orchestrai_django/src/orchestrai_django/components/service_runners/django_tasks.py
+++ b/packages/orchestrai_django/src/orchestrai_django/components/service_runners/django_tasks.py
@@ -1,54 +1,7 @@
-# orchestrai_django/components/service_runners/django_tasks.py
-"""Django Tasks-backed runner."""
+"""Deprecated Django Tasks-backed runner shim."""
 
+from ._messages import REMOVED_SERVICE_RUNNER_MESSAGE
 
-from typing import Any
+raise RuntimeError(REMOVED_SERVICE_RUNNER_MESSAGE)
 
-from orchestrai.components.services.runners import LocalServiceRunner
-from orchestrai_django import tasks
-
-
-class DjangoTaskServiceRunner:
-    """Queue services through the Django Tasks layer."""
-
-    name = "django"
-
-    def __init__(self) -> None:
-        self._local = LocalServiceRunner()
-
-    def enqueue(
-        self,
-        *,
-        service_cls: type[Any],
-        service_kwargs: dict[str, Any],
-        phase: str,
-        runner_kwargs: dict[str, Any] | None = None,
-    ) -> Any:
-        service_path = f"{service_cls.__module__}:{service_cls.__qualname__}"
-        payload: dict[str, Any] = {
-            "service_path": service_path,
-            "service_kwargs": dict(service_kwargs),
-            "phase": phase,
-            "runner_name": self.name,
-        }
-        if runner_kwargs:
-            payload["runner_kwargs"] = dict(runner_kwargs)
-        return tasks.enqueue_service(**payload)
-
-    def start(self, **payload: Any) -> Any:
-        return self._local.start(**payload)
-
-    def stream(self, **payload: Any) -> Any:
-        return self._local.stream(**payload)
-
-    def get_status(
-        self,
-        *,
-        service_cls: type[Any],
-        phase: str,
-    ) -> Any:
-        service_path = f"{service_cls.__module__}:{service_cls.__qualname__}"
-        return tasks.get_service_status(service_path=service_path, phase=phase)
-
-
-__all__ = ["DjangoTaskServiceRunner"]
+__all__: list[str] = []

--- a/packages/orchestrai_django/tests/test_service_runner_shim.py
+++ b/packages/orchestrai_django/tests/test_service_runner_shim.py
@@ -1,0 +1,62 @@
+import importlib
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REMOVED_SERVICE_RUNNER_MESSAGE = (
+    "Service runners have been removed. Use BaseService.task.run/arun or the Django task proxy."
+)
+
+SERVICE_RUNNER_PACKAGE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "orchestrai_django"
+    / "components"
+)
+
+MODULE_NAMES = [
+    "orchestrai_django.components.service_runners",
+    "orchestrai_django.components.service_runners.django_tasks",
+]
+
+
+def _clear_service_runner_modules() -> None:
+    for module_name in MODULE_NAMES:
+        sys.modules.pop(module_name, None)
+
+
+@pytest.fixture(autouse=True)
+def stub_components_package():
+    _clear_service_runner_modules()
+    original_components = sys.modules.pop("orchestrai_django.components", None)
+
+    stub = ModuleType("orchestrai_django.components")
+    stub.__path__ = [str(SERVICE_RUNNER_PACKAGE_PATH)]
+    sys.modules["orchestrai_django.components"] = stub
+
+    yield
+
+    for name in ["orchestrai_django.components", *MODULE_NAMES]:
+        sys.modules.pop(name, None)
+    if original_components is not None:
+        sys.modules["orchestrai_django.components"] = original_components
+
+
+def test_package_import_raises_immediately():
+    with pytest.raises(RuntimeError, match=re.escape(REMOVED_SERVICE_RUNNER_MESSAGE)):
+        importlib.import_module("orchestrai_django.components.service_runners")
+
+
+def test_django_tasks_import_raises_immediately():
+    with pytest.raises(RuntimeError, match=re.escape(REMOVED_SERVICE_RUNNER_MESSAGE)):
+        importlib.import_module("orchestrai_django.components.service_runners.django_tasks")
+
+
+def test_direct_class_import_is_blocked():
+    with pytest.raises(RuntimeError, match=re.escape(REMOVED_SERVICE_RUNNER_MESSAGE)):
+        from orchestrai_django.components.service_runners import (  # type: ignore # noqa: F401
+            DjangoTaskServiceRunner,
+        )


### PR DESCRIPTION
## Summary
- replace the Django service runner modules with an immediate runtime error and shared removal message
- clear exports so no runner symbols are exposed
- add tests confirming imports raise with guidance toward BaseService.task.run/arun or the Django task proxy

## Testing
- uv run pytest packages/orchestrai_django/tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69557223f2108333998f1b1f2f08a130)