### PR TITLE
Add ServiceCallMixin call entrypoints and clarify lifecycle API

### DIFF
--- a/packages/orchestrai/src/orchestrai/components/services/__init__.py
+++ b/packages/orchestrai/src/orchestrai/components/services/__init__.py
@@ -2,7 +2,7 @@
 
 from .calls import ServiceCall, assert_jsonable, to_jsonable
 from .discovery import discover_services, list_services
-from .execution import ExecutionLifecycleMixin
+from .execution import ExecutionLifecycleMixin, ServiceCallMixin
 from .exceptions import (
     MissingRequiredContextKeys,
     ServiceBuildRequestError,
@@ -24,6 +24,7 @@ __all__ = (
     "ServiceCall",
     "assert_jsonable",
     "to_jsonable",
+    "ServiceCallMixin",
     "ExecutionLifecycleMixin",
     "discover_services",
     "list_services",

--- a/packages/orchestrai/src/orchestrai/components/services/service.py
+++ b/packages/orchestrai/src/orchestrai/components/services/service.py
@@ -37,7 +37,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 
 from .calls import ServiceCall
 from .exceptions import ServiceBuildRequestError, ServiceCodecResolutionError, ServiceConfigError
-from .execution import ExecutionLifecycleMixin, resolve_call_client
+from .execution import ExecutionLifecycleMixin, ServiceCallMixin, resolve_call_client
 from .task_proxy import CoreTaskProxy, ServiceSpec, TaskDescriptor
 from ..base import BaseComponent
 from ..codecs.codec import BaseCodec
@@ -82,13 +82,15 @@ class ServiceEmitter(Protocol):
 CodecLike = Union[type[BaseCodec], BaseCodec, IdentityLike]
 
 
-class BaseService(IdentityMixin, LifecycleMixin, ExecutionLifecycleMixin, BaseComponent, ABC):
+class BaseService(IdentityMixin, LifecycleMixin, ServiceCallMixin, BaseComponent, ABC):
     """
     Abstract base for LLM-backed AI services.
 
     • Identity is exposed as `self.identity: Identity`, resolved by `IdentityMixin`.
     • Class attributes (domain/namespace/group/name) are resolver hints only (legacy `kind` is accepted as group).
     • Concrete services should rely on `self.identity.as_str` etc. instead of duplicating labels.
+    • Lifecycle execution lives in :class:`LifecycleMixin` (`execute` / `aexecute` return results).
+    • Service call orchestration lives in :class:`ServiceCallMixin` (`call` / `acall` return :class:`ServiceCall`).
     Codec precedence
     ----------------
     1) Per-call override provided at init (`codec=...`)


### PR DESCRIPTION
## Summary
- rename the service call mixin to `ServiceCallMixin`, add `call/acall` entrypoints, and keep the legacy alias
- clarify BaseService lifecycle versus call envelope responsibilities and route task proxies through the new APIs
- extend service call tests to cover call injection, failure recording, and sync/async results

## Testing
- uv run pytest packages/orchestrai

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695577f92ad0833391e5931c88929757)