### PR TITLE
Fail fast when AI enqueue unavailable; backfill patient conversations for all legacy simulations

### DIFF
--- a/SimWorks/api/v1/endpoints/messages.py
+++ b/SimWorks/api/v1/endpoints/messages.py
@@ -5,6 +5,7 @@ Uses cursor-based pagination for listing messages.
 """
 
 from asgiref.sync import async_to_sync
+from django.db import transaction
 from django.http import HttpRequest
 from ninja import Query, Router
 from ninja.errors import HttpError
@@ -218,28 +219,38 @@ def create_message(
     if conversation.is_locked:
         raise HttpError(400, "This conversation is locked")
 
-    # Create the user message
-    message = Message.objects.create(
-        simulation=sim,
-        conversation=conversation,
-        sender=user,
-        content=body.content,
-        role=RoleChoices.USER,
-        message_type=body.message_type,
-        is_from_ai=False,
-        display_name=user.get_full_name() or user.email,
-    )
+    with transaction.atomic():
+        # Create the user message
+        message = Message.objects.create(
+            simulation=sim,
+            conversation=conversation,
+            sender=user,
+            content=body.content,
+            role=RoleChoices.USER,
+            message_type=body.message_type,
+            is_from_ai=False,
+            display_name=user.get_full_name() or user.email,
+        )
 
-    logger.info(
-        "message.created",
-        message_id=message.pk,
-        simulation_id=simulation_id,
-        conversation_id=conversation.pk,
-        message_type=body.message_type,
-    )
+        logger.info(
+            "message.created",
+            message_id=message.pk,
+            simulation_id=simulation_id,
+            conversation_id=conversation.pk,
+            message_type=body.message_type,
+        )
 
-    # Enqueue the AI response generation (dispatched by conversation type)
-    _enqueue_ai_reply(conversation, simulation_id, message.pk)
+        # Enqueue the AI response generation (dispatched by conversation type)
+        call_id = _enqueue_ai_reply(conversation, simulation_id, message.pk)
+        if call_id is None:
+            logger.warning(
+                "message.ai_reply_not_enqueued",
+                simulation_id=simulation_id,
+                conversation_id=conversation.pk,
+                message_id=message.pk,
+                conversation_persona=conversation.conversation_type.ai_persona,
+            )
+            raise HttpError(400, "AI replies are not available for this conversation yet")
 
     # Return 202 Accepted since an AI response will be generated asynchronously
     return 202, message_to_out(message)

--- a/SimWorks/apps/simcore/migrations/0003_seed_conversation_types.py
+++ b/SimWorks/apps/simcore/migrations/0003_seed_conversation_types.py
@@ -89,8 +89,8 @@ def create_stitch_bot_user(apps, schema_editor):
 
 
 def backfill_conversations(apps, schema_editor):
-    """For every Simulation that has messages, create a patient Conversation
-    and link all existing messages to it."""
+    """For every legacy Simulation, ensure a patient Conversation exists,
+    then link any existing conversation-less messages to it."""
     Simulation = apps.get_model("simcore", "Simulation")
     Conversation = apps.get_model("simcore", "Conversation")
     ConversationType = apps.get_model("simcore", "ConversationType")
@@ -98,21 +98,12 @@ def backfill_conversations(apps, schema_editor):
 
     patient_type = ConversationType.objects.get(slug="simulated_patient")
 
-    # Find all simulation IDs that have at least one message
-    sim_ids_with_messages = (
-        Message.objects.filter(conversation__isnull=True)
-        .values_list("simulation_id", flat=True)
-        .distinct()
-    )
-
-    for sim_id in sim_ids_with_messages:
-        try:
-            sim = Simulation.objects.get(pk=sim_id)
-        except Simulation.DoesNotExist:
-            continue
+    # Ensure every existing simulation has a default patient conversation,
+    # even if it currently has zero messages.
+    for sim in Simulation.objects.all().iterator():
 
         conv, _ = Conversation.objects.get_or_create(
-            simulation=sim,
+            simulation_id=sim.id,
             conversation_type=patient_type,
             defaults={
                 "display_name": sim.sim_patient_display_name or "Patient",
@@ -121,7 +112,7 @@ def backfill_conversations(apps, schema_editor):
 
         # Bulk update messages for this simulation
         Message.objects.filter(
-            simulation_id=sim_id,
+            simulation_id=sim.id,
             conversation__isnull=True,
         ).update(conversation=conv)
 


### PR DESCRIPTION
### Motivation
- Prevent API from returning `202 Accepted` when no AI worker is actually enqueued, which causes feedback/coaching conversations to silently dead-end.
- Ensure legacy simulations that have zero messages still receive a default patient `Conversation` so runtime resolution does not produce `400 "No patient conversation found"` on first message.

### Description
- Wrap the message creation + enqueue flow in a DB transaction and require a successful enqueue call before returning `202` by updating `api/v1/endpoints/messages.py` to use `transaction.atomic()` and to check the return value of `_enqueue_ai_reply()`, logging and raising `HttpError(400)` when `None` is returned.
- Update the migration `apps/simcore/migrations/0003_seed_conversation_types.py` so `backfill_conversations()` iterates over all existing `Simulation` rows and ensures each simulation has a default patient `Conversation`, then bulk-updates any messages with `conversation__isnull=True` to point to that conversation.
- Key files changed: `SimWorks/api/v1/endpoints/messages.py` and `SimWorks/apps/simcore/migrations/0003_seed_conversation_types.py`.

### Testing
- Ran Django system checks with `uv run python manage.py check`, which completed successfully with unrelated deprecation warnings.
- Verified syntax/bytecode with `uv run python -m compileall api/v1/endpoints/messages.py apps/simcore/migrations/0003_seed_conversation_types.py`, which passed.
- Executed `uv run pytest apps/chatlab/tests.py -q` and observed pre-existing unrelated test failures in `apps/chatlab/tests.py` (these failures were not introduced by this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ce27ccf08333abea0cf1be4874f3)