### PR TITLE
Rename `tunnel` network to `_TunnelNet` in Docker Compose config

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -88,7 +88,7 @@ services:
       - server
     networks:
       - app
-      - tunnel
+      - _TunnelNet
 
   nginx-dev:
     extends:
@@ -183,6 +183,6 @@ volumes:
 networks:
   app:
     driver: bridge
-    # app: true
-  tunnel:
+    # internal: true
+  _TunnelNet:
     external: True


### PR DESCRIPTION
This pull request modifies the Docker Compose configuration to rename the network previously named `tunnel` to `_TunnelNet`, ensuring consistency in naming conventions across the project.

No additional changes were made outside of this configuration update.