### PR TITLE
Normalize injury codes and teach AI friendly labels

### DIFF
--- a/SimWorks/api/v1/endpoints/trainerlab.py
+++ b/SimWorks/api/v1/endpoints/trainerlab.py
@@ -43,6 +43,7 @@ from api.v1.sse import stream_outbox_events
 from apps.common.models import OutboxEvent
 from apps.common.ratelimit import api_rate_limit
 from apps.trainerlab.access import require_instructor_membership
+from apps.trainerlab.injury_dictionary import get_injury_dictionary_choices
 from apps.trainerlab.models import (
     ETCO2,
     SPO2,
@@ -223,9 +224,8 @@ def injury_dictionary(request: HttpRequest) -> dict[str, list[DictionaryItemOut]
     user = request.auth
     require_instructor_membership(user)
     return {
-        "categories": _build_dict_items(Injury.InjuryCategory.choices),
-        "regions": _build_dict_items(Injury.InjuryLocation.choices),
-        "kinds": _build_dict_items(Injury.InjuryKind.choices),
+        key: _build_dict_items(choices)
+        for key, choices in get_injury_dictionary_choices().items()
     }
 
 

--- a/SimWorks/api/v1/schemas/trainerlab.py
+++ b/SimWorks/api/v1/schemas/trainerlab.py
@@ -3,8 +3,13 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from apps.trainerlab.injury_dictionary import (
+    normalize_injury_category,
+    normalize_injury_kind,
+    normalize_injury_location,
+)
 from apps.trainerlab.models import (
     ScenarioInstruction,
     ScenarioInstructionPermission,
@@ -67,12 +72,36 @@ class SteerPromptIn(BaseModel):
 
 
 class InjuryCreateIn(BaseModel):
-    injury_category: str
-    injury_location: str
-    injury_kind: str
+    injury_category: str = Field(
+        ...,
+        description="Injury category code or friendly label (normalized to canonical code)",
+    )
+    injury_location: str = Field(
+        ...,
+        description="Injury location code or friendly label (normalized to canonical code)",
+    )
+    injury_kind: str = Field(
+        ...,
+        description="Injury kind code or friendly label (normalized to canonical code)",
+    )
     injury_description: str
     parent_injury_id: int | None = None
     supersedes_event_id: int | None = None
+
+    @field_validator("injury_category")
+    @classmethod
+    def _normalize_injury_category(cls, value: str) -> str:
+        return normalize_injury_category(value)
+
+    @field_validator("injury_location")
+    @classmethod
+    def _normalize_injury_location(cls, value: str) -> str:
+        return normalize_injury_location(value)
+
+    @field_validator("injury_kind")
+    @classmethod
+    def _normalize_injury_kind(cls, value: str) -> str:
+        return normalize_injury_kind(value)
 
 
 class IllnessCreateIn(BaseModel):

--- a/SimWorks/apps/trainerlab/injury_dictionary.py
+++ b/SimWorks/apps/trainerlab/injury_dictionary.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "build_injury_codebook_instruction",
+    "get_injury_dictionary_choices",
+    "get_injury_mapping_warnings",
+    "normalize_injury_category",
+    "normalize_injury_kind",
+    "normalize_injury_location",
+]
+
+
+@dataclass(frozen=True)
+class _ChoiceIndex:
+    field_name: str
+    code_to_label: dict[str, str]
+    normalized_to_code: dict[str, str]
+    codes: tuple[str, ...]
+    labels: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _InjuryMappingBundle:
+    category: _ChoiceIndex
+    location: _ChoiceIndex
+    kind: _ChoiceIndex
+    warnings: tuple[str, ...]
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.strip().split()).casefold()
+
+
+def _build_choice_index(*, field_name: str, choices: list[tuple[str, str]]) -> _ChoiceIndex:
+    code_to_label: dict[str, str] = {}
+    normalized_to_code: dict[str, str] = {}
+    codes: list[str] = []
+    labels: list[str] = []
+
+    for raw_code, raw_label in choices:
+        code = str(raw_code).strip()
+        label = " ".join(str(raw_label).strip().split())
+
+        if not code:
+            msg = f"Empty code in {field_name} choices"
+            raise RuntimeError(msg)
+        if code in code_to_label:
+            msg = f"Duplicate code {code!r} in {field_name} choices"
+            raise RuntimeError(msg)
+
+        code_to_label[code] = label
+        codes.append(code)
+        labels.append(label)
+
+        for normalized in (_normalize_text(code), _normalize_text(label)):
+            previous = normalized_to_code.get(normalized)
+            if previous and previous != code:
+                msg = (
+                    f"Ambiguous normalized token {normalized!r} in {field_name}: "
+                    f"{previous!r} vs {code!r}"
+                )
+                raise RuntimeError(msg)
+            normalized_to_code[normalized] = code
+
+    return _ChoiceIndex(
+        field_name=field_name,
+        code_to_label=code_to_label,
+        normalized_to_code=normalized_to_code,
+        codes=tuple(codes),
+        labels=tuple(labels),
+    )
+
+
+def _build_integrity_warnings() -> tuple[str, ...]:
+    from apps.trainerlab.models import Injury
+
+    warnings: list[str] = []
+    for member in Injury.InjuryCategory:
+        if "_" in member.name:
+            continue
+        if len(member.name) <= 4 and member.name != member.value:
+            warnings.append(
+                "InjuryCategory member "
+                f"{member.name!r} maps to code {member.value!r}; review intent."
+            )
+    return tuple(warnings)
+
+
+@lru_cache(maxsize=1)
+def _build_bundle() -> _InjuryMappingBundle:
+    from apps.trainerlab.models import Injury
+
+    category = _build_choice_index(
+        field_name="injury_category",
+        choices=[(str(code), str(label)) for code, label in Injury.InjuryCategory.choices],
+    )
+    location = _build_choice_index(
+        field_name="injury_location",
+        choices=[(str(code), str(label)) for code, label in Injury.InjuryLocation.choices],
+    )
+    kind = _build_choice_index(
+        field_name="injury_kind",
+        choices=[(str(code), str(label)) for code, label in Injury.InjuryKind.choices],
+    )
+    warnings = _build_integrity_warnings()
+    for warning in warnings:
+        logger.warning("TrainerLab injury mapping integrity warning: %s", warning)
+
+    return _InjuryMappingBundle(
+        category=category,
+        location=location,
+        kind=kind,
+        warnings=warnings,
+    )
+
+
+def _resolve_choice(index: _ChoiceIndex, value: Any) -> str:
+    raw_value = value.value if hasattr(value, "value") else value
+    if not isinstance(raw_value, str):
+        raise ValueError(f"{index.field_name} must be a string")
+
+    normalized = _normalize_text(raw_value)
+    if not normalized:
+        raise ValueError(f"{index.field_name} cannot be blank")
+
+    code = index.normalized_to_code.get(normalized)
+    if code:
+        return code
+
+    allowed_codes = ", ".join(index.codes)
+    allowed_labels = "; ".join(index.labels)
+    raise ValueError(
+        f"Invalid {index.field_name!r} value {raw_value!r}. "
+        f"Allowed codes: {allowed_codes}. "
+        f"Allowed labels: {allowed_labels}."
+    )
+
+
+def normalize_injury_category(value: Any) -> str:
+    return _resolve_choice(_build_bundle().category, value)
+
+
+def normalize_injury_location(value: Any) -> str:
+    return _resolve_choice(_build_bundle().location, value)
+
+
+def normalize_injury_kind(value: Any) -> str:
+    return _resolve_choice(_build_bundle().kind, value)
+
+
+def get_injury_dictionary_choices() -> dict[str, list[tuple[str, str]]]:
+    bundle = _build_bundle()
+    return {
+        "categories": list(bundle.category.code_to_label.items()),
+        "regions": list(bundle.location.code_to_label.items()),
+        "kinds": list(bundle.kind.code_to_label.items()),
+    }
+
+
+def get_injury_mapping_warnings() -> tuple[str, ...]:
+    return _build_bundle().warnings
+
+
+def _format_codebook_pairs(pairs: list[tuple[str, str]]) -> str:
+    return ", ".join(f"{code}={label}" for code, label in pairs)
+
+
+def build_injury_codebook_instruction() -> str:
+    choices = get_injury_dictionary_choices()
+    categories = _format_codebook_pairs(choices["categories"])
+    regions = _format_codebook_pairs(choices["regions"])
+    kinds = _format_codebook_pairs(choices["kinds"])
+    return (
+        "### Injury Codebook\n"
+        "- Return canonical codes for `injury_category`, `injury_location`, and `injury_kind`.\n"
+        "- You may reason with friendly labels, but your final output must use codes.\n"
+        f"- `injury_category` codes: {categories}\n"
+        f"- `injury_location` codes: {regions}\n"
+        f"- `injury_kind` codes: {kinds}\n"
+    )

--- a/SimWorks/apps/trainerlab/orca/instructions/__init__.py
+++ b/SimWorks/apps/trainerlab/orca/instructions/__init__.py
@@ -1,9 +1,10 @@
-from .initial import InitialResponseMixin, TrainerLabMixin
+from .initial import InitialResponseMixin, InjuryCodebookMixin, TrainerLabMixin
 from .modifiers import CombatMixin, MilitaryMedicMixin, TraumaMixin
 
 __all__ = [
     "CombatMixin",
     "InitialResponseMixin",
+    "InjuryCodebookMixin",
     "MilitaryMedicMixin",
     "TrainerLabMixin",
     "TraumaMixin",

--- a/SimWorks/apps/trainerlab/orca/instructions/initial.py
+++ b/SimWorks/apps/trainerlab/orca/instructions/initial.py
@@ -1,11 +1,14 @@
 # trainerlab/orca/instructions/initial.py
 
+from apps.trainerlab.injury_dictionary import build_injury_codebook_instruction
 from orchestrai.instructions import BaseInstruction
 from orchestrai_django.decorators import orca
 
 from ..identity_mixins import TrainerlabNamespaceMixin as NsMixin
 
 __all__ = [
+    "InitialResponseMixin",
+    "InjuryCodebookMixin",
     "TrainerLabMixin",
 ]
 
@@ -39,3 +42,9 @@ class InitialResponseMixin(NsMixin, BaseInstruction):
         "ETCO2, "
         "blood glucose level."
     )
+
+
+@orca.instruction(order=15)
+class InjuryCodebookMixin(NsMixin, BaseInstruction):
+    def render_instruction(self) -> str:
+        return build_injury_codebook_instruction()

--- a/SimWorks/apps/trainerlab/orca/schemas/types/injury.py
+++ b/SimWorks/apps/trainerlab/orca/schemas/types/injury.py
@@ -1,8 +1,13 @@
 # trainerlab/orca/types/injury.py
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
+from apps.trainerlab.injury_dictionary import (
+    normalize_injury_category,
+    normalize_injury_kind,
+    normalize_injury_location,
+)
 from apps.trainerlab.models import Illness as ORMIllness, Injury as ORMInjury
 from orchestrai_django.types import StrictBaseModel
 
@@ -21,6 +26,21 @@ class Injury(StrictBaseModel):
     # parent_injury
 
     __orm_model__ = "trainerlab.Injury"
+
+    @field_validator("injury_category", mode="before")
+    @classmethod
+    def _normalize_injury_category(cls, value):
+        return normalize_injury_category(value)
+
+    @field_validator("injury_location", mode="before")
+    @classmethod
+    def _normalize_injury_location(cls, value):
+        return normalize_injury_location(value)
+
+    @field_validator("injury_kind", mode="before")
+    @classmethod
+    def _normalize_injury_kind(cls, value):
+        return normalize_injury_kind(value)
 
 
 class Illness(StrictBaseModel):

--- a/SimWorks/apps/trainerlab/orca/services/initial.py
+++ b/SimWorks/apps/trainerlab/orca/services/initial.py
@@ -10,6 +10,7 @@ from orchestrai_django.decorators import orca
 from ..instructions import (
     CombatMixin,
     InitialResponseMixin,
+    InjuryCodebookMixin,
     MilitaryMedicMixin,
     TrainerLabMixin,
     TraumaMixin,
@@ -25,6 +26,7 @@ class GenerateInitialScenario(
     BaseStitchPersona,
     TrainerLabMixin,
     InitialResponseMixin,
+    InjuryCodebookMixin,
     MilitaryMedicMixin,
     TraumaMixin,
     CombatMixin,

--- a/tests/api/test_trainerlab.py
+++ b/tests/api/test_trainerlab.py
@@ -395,6 +395,60 @@ class TestTrainerLabEvents:
 
         assert TrainerCommand.objects.filter(idempotency_key="steer-1").count() == 1
 
+    def test_injury_event_accepts_friendly_labels(
+        self,
+        auth_client_factory,
+        instructor_user,
+        instructor_membership,
+    ):
+        from apps.trainerlab.models import Injury
+
+        client = auth_client_factory(instructor_user)
+        session = _create_session(client, idempotency_key="event-friendly-label-session")
+        session_id = session["id"]
+
+        response = client.post(
+            f"/api/v1/trainerlab/sessions/{session_id}/events/injuries/",
+            data={
+                "injury_category": "massive hemorrhage",
+                "injury_location": "left upper arm",
+                "injury_kind": "laceration",
+                "injury_description": "Friendly label injury",
+            },
+            content_type="application/json",
+            HTTP_IDEMPOTENCY_KEY="injury-friendly-1",
+        )
+        assert response.status_code == 200
+
+        injury = Injury.objects.get(injury_description="Friendly label injury")
+        assert injury.injury_category == "M"
+        assert injury.injury_location == "LUA"
+        assert injury.injury_kind == "LAC"
+
+    def test_injury_event_rejects_unknown_label(
+        self,
+        auth_client_factory,
+        instructor_user,
+        instructor_membership,
+    ):
+        client = auth_client_factory(instructor_user)
+        session = _create_session(client, idempotency_key="event-invalid-label-session")
+        session_id = session["id"]
+
+        response = client.post(
+            f"/api/v1/trainerlab/sessions/{session_id}/events/injuries/",
+            data={
+                "injury_category": "massive hemorrhage",
+                "injury_location": "not-a-real-location",
+                "injury_kind": "laceration",
+                "injury_description": "Should fail",
+            },
+            content_type="application/json",
+            HTTP_IDEMPOTENCY_KEY="injury-invalid-1",
+        )
+        assert response.status_code == 422
+        assert "injury_location" in response.content.decode("utf-8")
+
     def test_sse_stream_endpoint_responds(
         self,
         auth_client_factory,
@@ -445,6 +499,25 @@ class TestTrainerLabDictionaries:
         airway_group = next(group for group in data if group["group"] == "Airway")
         airway_codes = {item["code"] for item in airway_group["items"]}
         assert "A-NPA" in airway_codes
+
+    def test_injury_dictionary_matches_shared_mapping(
+        self,
+        auth_client_factory,
+        instructor_user,
+        instructor_membership,
+    ):
+        from apps.trainerlab.injury_dictionary import get_injury_dictionary_choices
+
+        client = auth_client_factory(instructor_user)
+        response = client.get("/api/v1/trainerlab/dictionaries/injuries/")
+        assert response.status_code == 200
+        data = response.json()
+        expected = get_injury_dictionary_choices()
+
+        for key in ("categories", "regions", "kinds"):
+            expected_pairs = {(code, label) for code, label in expected[key]}
+            actual_pairs = {(item["code"], item["label"]) for item in data[key]}
+            assert actual_pairs == expected_pairs
 
 
 @pytest.mark.django_db

--- a/tests/simulation/test_trainerlab_initial_persist.py
+++ b/tests/simulation/test_trainerlab_initial_persist.py
@@ -131,6 +131,11 @@ class TestTrainerLabInitialPersistence:
 
         assert isinstance(result, Injury)
         assert await Injury.objects.filter(simulation_id=context.simulation_id).acount() == 1
+        persisted_injury = await Injury.objects.filter(simulation_id=context.simulation_id).afirst()
+        assert persisted_injury is not None
+        assert persisted_injury.injury_category == "M"
+        assert persisted_injury.injury_location == "HLA"
+        assert persisted_injury.injury_kind == "LAC"
         assert await Illness.objects.filter(simulation_id=context.simulation_id).acount() == 1
         assert await HeartRate.objects.filter(simulation_id=context.simulation_id).acount() == 1
         assert (
@@ -205,6 +210,21 @@ class TestTrainerLabInitialPersistence:
         assert example_vital is not None
         assert example_vital.payload["call_id"] == str(context.call_id)
 
+    async def test_accepts_friendly_injury_labels_and_normalizes_to_codes(self, context):
+        payload = _initial_payload()
+        payload["conditions"][0]["injury_category"] = "massive hemorrhage"
+        payload["conditions"][0]["injury_location"] = "  left anterior head "
+        payload["conditions"][0]["injury_kind"] = "laceration"
+
+        schema = InitialScenarioSchema.model_validate(payload)
+        await persist_schema(schema, context)
+
+        injury = await Injury.objects.filter(simulation_id=context.simulation_id).afirst()
+        assert injury is not None
+        assert injury.injury_category == "M"
+        assert injury.injury_location == "HLA"
+        assert injury.injury_kind == "LAC"
+
 
 def test_validates_base_vital_min_max_range():
     payload = _initial_payload()
@@ -232,3 +252,11 @@ def test_measurement_schema_omits_legacy_fields():
     assert "timestamp" not in heart_rate_props
     assert "kind" not in heart_rate_props
     assert "key" not in heart_rate_props
+
+
+def test_rejects_unknown_injury_labels():
+    payload = _initial_payload()
+    payload["conditions"][0]["injury_location"] = "unknown body part"
+
+    with pytest.raises(ValidationError):
+        InitialScenarioSchema.model_validate(payload)

--- a/tests/simulation/test_trainerlab_initial_service.py
+++ b/tests/simulation/test_trainerlab_initial_service.py
@@ -1,5 +1,9 @@
 from apps.simcore.orca.instructions import BaseStitchPersona
-from apps.trainerlab.orca.instructions import InitialResponseMixin, TrainerLabMixin
+from apps.trainerlab.orca.instructions import (
+    InitialResponseMixin,
+    InjuryCodebookMixin,
+    TrainerLabMixin,
+)
 from apps.trainerlab.orca.services import GenerateInitialScenario
 
 
@@ -11,6 +15,7 @@ class TestGenerateInitialScenarioService:
         assert BaseStitchPersona in service._instruction_classes
         assert TrainerLabMixin in service._instruction_classes
         assert InitialResponseMixin in service._instruction_classes
+        assert InjuryCodebookMixin in service._instruction_classes
 
     def test_service_instruction_ordering(self):
         service = GenerateInitialScenario(context={"simulation_id": 1})
@@ -18,3 +23,13 @@ class TestGenerateInitialScenarioService:
 
         assert names.index("BaseStitchPersona") < names.index("TrainerLabMixin")
         assert names.index("TrainerLabMixin") < names.index("InitialResponseMixin")
+        assert names.index("InitialResponseMixin") < names.index("InjuryCodebookMixin")
+
+    def test_injury_codebook_instruction_contains_canonical_examples(self):
+        service = GenerateInitialScenario(context={"simulation_id": 1})
+        codebook = InjuryCodebookMixin.render_instruction(service)
+
+        assert "Injury Codebook" in codebook
+        assert "M=Massive Hemorrhage" in codebook
+        assert "HLA=Left Anterior Head" in codebook
+        assert "LAC=Laceration" in codebook

--- a/tests/simulation/test_trainerlab_injury_dictionary.py
+++ b/tests/simulation/test_trainerlab_injury_dictionary.py
@@ -1,0 +1,43 @@
+import pytest
+
+from apps.trainerlab.injury_dictionary import (
+    get_injury_dictionary_choices,
+    get_injury_mapping_warnings,
+    normalize_injury_category,
+    normalize_injury_kind,
+    normalize_injury_location,
+)
+from apps.trainerlab.models import Injury
+
+
+def test_dictionary_choices_match_orm_choices():
+    choices = get_injury_dictionary_choices()
+
+    assert choices["categories"] == [
+        (str(code), str(label)) for code, label in Injury.InjuryCategory.choices
+    ]
+    assert choices["regions"] == [
+        (str(code), str(label)) for code, label in Injury.InjuryLocation.choices
+    ]
+    assert choices["kinds"] == [
+        (str(code), str(label)) for code, label in Injury.InjuryKind.choices
+    ]
+
+
+def test_normalizes_codes_and_friendly_labels():
+    assert normalize_injury_category("m") == "M"
+    assert normalize_injury_category(" Massive   Hemorrhage ") == "M"
+    assert normalize_injury_location("hla") == "HLA"
+    assert normalize_injury_location("left anterior head") == "HLA"
+    assert normalize_injury_kind("laceration") == "LAC"
+    assert normalize_injury_kind(" LAC ") == "LAC"
+
+
+def test_rejects_unknown_values_with_explicit_error():
+    with pytest.raises(ValueError, match="Invalid 'injury_location' value"):
+        normalize_injury_location("not-a-real-location")
+
+
+def test_integrity_guard_surfaces_pfc_pc_mismatch_warning():
+    warnings = get_injury_mapping_warnings()
+    assert any("PFC" in warning and "PC" in warning for warning in warnings)


### PR DESCRIPTION
Summary
- introduce a shared injury dictionary utility so TrainerLab/API inputs can normalize either canonical codes or friendly labels and propagate explicit validation
- extend TrainerLab AI schema, instructions, and services to load the codebook, normalize dual inputs, and still persist canonical codes
- reuse the same mapping for public endpoints and dictionary responses, plus add an integrity guard around enum generation to catch anomalies early

Testing
- Not run (not requested)