### PR TITLE
Allow create_dev_user management command to run outside debug mode

### DIFF
--- a/SimWorks/apps/accounts/management/commands/create_dev_user.py
+++ b/SimWorks/apps/accounts/management/commands/create_dev_user.py
@@ -11,15 +11,11 @@ DEV_PASSWORD = "dev"
 class Command(BaseCommand):
     help = (
         "Create a dev user (dev@medsim.local) if it does not exist. "
-        "Only runs when DJANGO_CREATE_DEV_USER=true and DJANGO_DEBUG=true."
+        "Only runs when DJANGO_CREATE_DEV_USER=true."
     )
 
     def handle(self, *args, **options):
         from apps.accounts.models import User, UserRole
-
-        if not bool_from_env("DJANGO_DEBUG"):
-            self.stdout.write(self.style.WARNING("Skipped: DJANGO_DEBUG is not enabled."))
-            return
 
         if not bool_from_env("DJANGO_CREATE_DEV_USER"):
             self.stdout.write(self.style.WARNING("Skipped: DJANGO_CREATE_DEV_USER is not enabled."))


### PR DESCRIPTION
### Motivation
- Allow the `create_dev_user` management command to be executed in non-debug environments (for example staging) while still guarding with `DJANGO_CREATE_DEV_USER` so dev users can be created where `DJANGO_DEBUG` is false.

### Description
- Removed the `DJANGO_DEBUG` runtime guard and updated the command help text in `SimWorks/apps/accounts/management/commands/create_dev_user.py` so the command now runs when `DJANGO_CREATE_DEV_USER=true` regardless of `DJANGO_DEBUG`.

### Testing
- Ran `uv run python SimWorks/manage.py check` which completed successfully with no system check issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b367f75dec83339884f71b204d1546)