### PR TITLE
fix: remove composite indexes on Intervention referencing non-local field

### DIFF
--- a/SimWorks/apps/trainerlab/migrations/0010_intervention_structured_fields.py
+++ b/SimWorks/apps/trainerlab/migrations/0010_intervention_structured_fields.py
@@ -88,16 +88,4 @@ class Migration(migrations.Migration):
             name="details_json",
             field=models.JSONField(blank=True, default=dict),
         ),
-        migrations.AddIndex(
-            model_name="intervention",
-            index=models.Index(
-                fields=["simulation", "intervention_type"], name="idx_intervention_type"
-            ),
-        ),
-        migrations.AddIndex(
-            model_name="intervention",
-            index=models.Index(
-                fields=["simulation", "site_code"], name="idx_intervention_site"
-            ),
-        ),
     ]

--- a/SimWorks/apps/trainerlab/migrations/0011_remove_intervention_invalid_indexes.py
+++ b/SimWorks/apps/trainerlab/migrations/0011_remove_intervention_invalid_indexes.py
@@ -5,25 +5,17 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     """
-    Remove composite indexes that reference 'simulation', which is defined on
-    the parent model (ABCEvent) and is not local to Intervention. Multi-table
-    inheritance prohibits non-local fields in Meta.indexes (models.E016).
+    No-op migration. The composite indexes on Intervention that referenced
+    'simulation' (a non-local field from parent model ABCEvent) were removed
+    from migration 0010 before being applied, so there is nothing to remove here.
 
-    The individual fields (intervention_type, site_code) already carry
-    db_index=True so no query-performance regression occurs.
+    Multi-table inheritance prohibits non-local fields in Meta.indexes (models.E016).
+    The individual fields (intervention_type, site_code) carry db_index=True so
+    no query-performance regression occurs.
     """
 
     dependencies = [
         ("trainerlab", "0010_intervention_structured_fields"),
     ]
 
-    operations = [
-        migrations.RemoveIndex(
-            model_name="intervention",
-            name="idx_intervention_type",
-        ),
-        migrations.RemoveIndex(
-            model_name="intervention",
-            name="idx_intervention_site",
-        ),
-    ]
+    operations = []


### PR DESCRIPTION
Migration 0010 added composite indexes on `Intervention` that included
`simulation`, a field defined on the parent `ABCEvent` model. Django's
multi-table inheritance prohibits referencing non-local fields in
`Meta.indexes` (models.E016), causing the migration to fail on PostgreSQL.

Fix: remove the two `AddIndex` operations from 0010 so the indexes are
never created. Update 0011 to a no-op since there is nothing left to
remove. The individual fields `intervention_type` and `site_code` already
carry `db_index=True`, so there is no query-performance regression.

https://claude.ai/code/session_01LATtHRPxznSS55x7TJfWp6