### PR TITLE
Disable Logfire console exporter in local environments

### DIFF
--- a/SimWorks/config/observability_settings.py
+++ b/SimWorks/config/observability_settings.py
@@ -11,7 +11,9 @@ if logfire_token:
     logfire.configure(token=logfire_token)
 else:
     # Allow local/test environments to run without Logfire authentication.
-    logfire.configure(send_to_logfire=False)
+    # console=False suppresses the local OTel console exporter that would otherwise
+    # duplicate every log line already printed by the Django console handler.
+    logfire.configure(send_to_logfire=False, console=False)
 
 logfire.instrument_httpx(
     capture_all=True


### PR DESCRIPTION
## Summary
Suppress the Logfire OTel console exporter in local and test environments to prevent duplicate log output.

## Changes
- Updated `logfire.configure()` call to include `console=False` parameter when running without Logfire authentication
- Added explanatory comment clarifying that this prevents duplication of log lines already printed by the Django console handler

## Details
In local/test environments where Logfire authentication is not available, the OTel console exporter was outputting every log line to the console in addition to the logs already being printed by Django's console handler. This change disables the console exporter while keeping `send_to_logfire=False` to prevent attempting to send telemetry to the Logfire service.

https://claude.ai/code/session_01PKnDeTdQLGKEDo3ia5e31Q