### PR TITLE
Fix Django index names that violate 30-character limit

### DIFF
--- a/SimWorks/apps/accounts/migrations/0005_rename_membership_indexes.py
+++ b/SimWorks/apps/accounts/migrations/0005_rename_membership_indexes.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0004_backfill_personal_accounts"),
+    ]
+
+    operations = [
+        migrations.RenameIndex(
+            model_name="accountmembership",
+            old_name="idx_account_membership_user_status",
+            new_name="idx_acct_mship_user_status",
+        ),
+        migrations.RenameIndex(
+            model_name="accountmembership",
+            old_name="idx_account_membership_invite_email",
+            new_name="idx_acct_mship_invite_email",
+        ),
+    ]

--- a/SimWorks/apps/accounts/models.py
+++ b/SimWorks/apps/accounts/models.py
@@ -300,10 +300,10 @@ class AccountMembership(models.Model):
                 fields=["account", "status", "role"],
                 name="idx_account_membership_acl",
             ),
-            models.Index(fields=["user", "status"], name="idx_account_membership_user_status"),
+            models.Index(fields=["user", "status"], name="idx_acct_mship_user_status"),
             models.Index(
                 fields=["invite_email", "status"],
-                name="idx_account_membership_invite_email",
+                name="idx_acct_mship_invite_email",
             ),
         ]
 

--- a/SimWorks/apps/billing/migrations/0004_rename_subscription_index.py
+++ b/SimWorks/apps/billing/migrations/0004_rename_subscription_index.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("billing", "0003_backfill_legacy_lab_memberships"),
+    ]
+
+    operations = [
+        migrations.RenameIndex(
+            model_name="subscription",
+            old_name="idx_subscription_account_status",
+            new_name="idx_sub_account_status",
+        ),
+    ]

--- a/SimWorks/apps/billing/models.py
+++ b/SimWorks/apps/billing/models.py
@@ -103,7 +103,7 @@ class Subscription(models.Model):
             ),
         ]
         indexes = [
-            models.Index(fields=["account", "status"], name="idx_subscription_account_status"),
+            models.Index(fields=["account", "status"], name="idx_sub_account_status"),
             models.Index(fields=["plan_code", "status"], name="idx_subscription_plan_status"),
         ]
 


### PR DESCRIPTION
### Motivation
- Django system checks raised `models.E034` errors because several explicit index names exceeded the 30-character limit, preventing migrations from running cleanly.

### Description
- Shortened two `AccountMembership` index names in `SimWorks/apps/accounts/models.py` to `idx_acct_mship_user_status` and `idx_acct_mship_invite_email` to keep names under 30 characters.
- Shortened the `Subscription` account/status index name in `SimWorks/apps/billing/models.py` to `idx_sub_account_status` to satisfy the same constraint.
- Added migrations that use `migrations.RenameIndex` to rename the existing indexes in-place: `SimWorks/apps/accounts/migrations/0005_rename_membership_indexes.py` and `SimWorks/apps/billing/migrations/0004_rename_subscription_index.py`.

### Testing
- Located offending names with `rg` and verified the new index name lengths with a shell check showing `26`, `27`, and `22` characters respectively, all under the 30-character limit.
- Ran `git diff --check` to validate no whitespace/diff issues (passed).
- Attempted to run `uv run --python 3.14 python manage.py makemigrations accounts billing`, but the Django command could not complete in this environment due to interpreter/package incompatibilities (`openai`/`pydantic` import error under the available Python build), so full runtime migration validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d0f0e26c8333a26b3ad00ce6d7cf)