### PR TITLE
feat(api): add build info endpoint

### DIFF
--- a/SimWorks/api/v1/api.py
+++ b/SimWorks/api/v1/api.py
@@ -14,6 +14,7 @@ from api.v1.auth import JWTAuth
 from api.v1.endpoints.accounts import router as accounts_router
 from api.v1.endpoints.auth import router as auth_router
 from api.v1.endpoints.billing import router as billing_router
+from api.v1.endpoints.build_info import router as build_info_router
 from api.v1.endpoints.chatlab import router as chatlab_router
 from api.v1.endpoints.conversations import router as conversations_router
 from api.v1.endpoints.events import router as events_router
@@ -221,6 +222,7 @@ def health_check_jwt(request: HttpRequest) -> HealthResponse:
 api.add_router("/auth", auth_router)
 api.add_router("/accounts", accounts_router)
 api.add_router("/billing", billing_router)
+api.add_router("", build_info_router)
 api.add_router("/simulations", simulations_router)
 api.add_router("/simulations", conversations_router)  # Conversations nested under simulations
 api.add_router("/simulations", messages_router)  # Messages are nested under simulations

--- a/SimWorks/api/v1/endpoints/build_info.py
+++ b/SimWorks/api/v1/endpoints/build_info.py
@@ -13,8 +13,8 @@ router = Router(tags=["system"])
     "/build-info/",
     response=BuildInfoOut,
     summary="Get build metadata",
-    description="Returns best-effort backend build metadata for app startup screens.",
+    description="Returns best-effort backend build metadata for app startup and debug screens.",
 )
 def build_info(request: HttpRequest) -> BuildInfoOut:
-    """Expose backend build metadata used by the iOS splash screen."""
+    """Expose backend artifact metadata used by the iOS splash screen."""
     return BuildInfoOut.model_validate(get_build_info_payload())

--- a/SimWorks/api/v1/endpoints/build_info.py
+++ b/SimWorks/api/v1/endpoints/build_info.py
@@ -1,0 +1,20 @@
+"""Read-only build metadata endpoint for app splash/startup display."""
+
+from django.http import HttpRequest
+from ninja import Router
+
+from api.v1.schemas.build_info import BuildInfoOut
+from apps.common.services.build_info import get_build_info_payload
+
+router = Router(tags=["system"])
+
+
+@router.get(
+    "/build-info/",
+    response=BuildInfoOut,
+    summary="Get build metadata",
+    description="Returns best-effort backend build metadata for app startup screens.",
+)
+def build_info(request: HttpRequest) -> BuildInfoOut:
+    """Expose backend build metadata used by the iOS splash screen."""
+    return BuildInfoOut.model_validate(get_build_info_payload())

--- a/SimWorks/api/v1/schemas/build_info.py
+++ b/SimWorks/api/v1/schemas/build_info.py
@@ -1,0 +1,27 @@
+"""Schemas for build metadata exposed to app clients."""
+
+from pydantic import BaseModel, Field
+
+
+class BackendBuildInfoOut(BaseModel):
+    """Backend runtime metadata for startup display."""
+
+    version: str | None = Field(default=None, description="Installed backend package version")
+    commit: str | None = Field(default=None, description="Injected backend source commit SHA")
+    build_time: str | None = Field(
+        default=None,
+        description="Backend build timestamp when available",
+    )
+
+
+class OrchestraiBuildInfoOut(BaseModel):
+    """OrchestrAI package metadata for startup display."""
+
+    version: str | None = Field(default=None, description="Installed OrchestrAI package version")
+
+
+class BuildInfoOut(BaseModel):
+    """Best-effort build metadata for the mobile splash screen."""
+
+    backend: BackendBuildInfoOut
+    orchestrai: OrchestraiBuildInfoOut

--- a/SimWorks/api/v1/schemas/build_info.py
+++ b/SimWorks/api/v1/schemas/build_info.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 
 class BackendBuildInfoOut(BaseModel):
-    """Backend runtime metadata for startup display."""
+    """Backend artifact metadata for startup display."""
 
     version: str | None = Field(default=None, description="Installed backend package version")
     commit: str | None = Field(default=None, description="Injected backend source commit SHA")

--- a/SimWorks/api/v1/schemas/build_info.py
+++ b/SimWorks/api/v1/schemas/build_info.py
@@ -10,7 +10,7 @@ class BackendBuildInfoOut(BaseModel):
     commit: str | None = Field(default=None, description="Injected backend source commit SHA")
     build_time: str | None = Field(
         default=None,
-        description="Backend build timestamp when available",
+        description="Backend artifact build timestamp in UTC when supplied by the build pipeline",
     )
 
 

--- a/SimWorks/apps/common/services/__init__.py
+++ b/SimWorks/apps/common/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service helpers for cross-cutting common app functionality."""

--- a/SimWorks/apps/common/services/build_info.py
+++ b/SimWorks/apps/common/services/build_info.py
@@ -1,14 +1,17 @@
-"""Build metadata helpers for frontend splash/startup display."""
+"""Build metadata helpers for frontend splash/startup and debug display."""
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
+import tomllib
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-BACKEND_PACKAGE_NAME = "MedSim"
 ORCHESTRAI_PACKAGE_NAME = "orchestrai"
 BACKEND_COMMIT_ENV_VARS = ("APP_GIT_SHA", "GIT_SHA")
+BACKEND_BUILD_TIME_ENV_VARS = ("APP_BUILD_TIME", "BUILD_TIME")
+PYPROJECT_TOML_PATH = Path(__file__).resolve().parents[4] / "pyproject.toml"
 
 
 def safe_package_version(package_name: str) -> str | None:
@@ -19,18 +22,42 @@ def safe_package_version(package_name: str) -> str | None:
         return None
 
 
+def get_backend_package_name() -> str | None:
+    """Return the canonical backend distribution name from ``pyproject.toml``."""
+    try:
+        project_data = tomllib.loads(PYPROJECT_TOML_PATH.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    package_name = str(project_data.get("project", {}).get("name") or "").strip()
+    return package_name or None
+
+
 def get_backend_version() -> str | None:
-    """Return the installed MedSim package version."""
-    return safe_package_version(BACKEND_PACKAGE_NAME)
+    """Return the installed backend package version using the canonical project name."""
+    package_name = get_backend_package_name()
+    if not package_name:
+        return None
+    return safe_package_version(package_name)
 
 
-def get_backend_commit() -> str | None:
-    """Return the injected backend commit SHA from the environment."""
-    for env_var in BACKEND_COMMIT_ENV_VARS:
+def _first_non_blank_env_value(env_vars: tuple[str, ...]) -> str | None:
+    """Return the first non-blank environment value from the provided precedence list."""
+    for env_var in env_vars:
         value = os.getenv(env_var, "").strip()
         if value:
             return value
     return None
+
+
+def get_backend_commit() -> str | None:
+    """Return the injected backend commit SHA from the environment."""
+    return _first_non_blank_env_value(BACKEND_COMMIT_ENV_VARS)
+
+
+def get_backend_build_time() -> str | None:
+    """Return the injected UTC artifact build timestamp from the environment."""
+    return _first_non_blank_env_value(BACKEND_BUILD_TIME_ENV_VARS)
 
 
 def get_orchestrai_version() -> str | None:
@@ -39,12 +66,12 @@ def get_orchestrai_version() -> str | None:
 
 
 def get_build_info_payload() -> dict[str, Any]:
-    """Return best-effort build metadata for client splash screens."""
+    """Return best-effort build metadata for client startup/debug display."""
     return {
         "backend": {
             "version": get_backend_version(),
             "commit": get_backend_commit(),
-            "build_time": None,
+            "build_time": get_backend_build_time(),
         },
         "orchestrai": {
             "version": get_orchestrai_version(),

--- a/SimWorks/apps/common/services/build_info.py
+++ b/SimWorks/apps/common/services/build_info.py
@@ -1,0 +1,52 @@
+"""Build metadata helpers for frontend splash/startup display."""
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+BACKEND_PACKAGE_NAME = "MedSim"
+ORCHESTRAI_PACKAGE_NAME = "orchestrai"
+BACKEND_COMMIT_ENV_VARS = ("APP_GIT_SHA", "GIT_SHA")
+
+
+def safe_package_version(package_name: str) -> str | None:
+    """Return installed package version metadata when available."""
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None
+
+
+def get_backend_version() -> str | None:
+    """Return the installed MedSim package version."""
+    return safe_package_version(BACKEND_PACKAGE_NAME)
+
+
+def get_backend_commit() -> str | None:
+    """Return the injected backend commit SHA from the environment."""
+    for env_var in BACKEND_COMMIT_ENV_VARS:
+        value = os.getenv(env_var, "").strip()
+        if value:
+            return value
+    return None
+
+
+def get_orchestrai_version() -> str | None:
+    """Return the installed OrchestrAI package version."""
+    return safe_package_version(ORCHESTRAI_PACKAGE_NAME)
+
+
+def get_build_info_payload() -> dict[str, Any]:
+    """Return best-effort build metadata for client splash screens."""
+    return {
+        "backend": {
+            "version": get_backend_version(),
+            "commit": get_backend_commit(),
+            "build_time": None,
+        },
+        "orchestrai": {
+            "version": get_orchestrai_version(),
+        },
+    }

--- a/SimWorks/apps/common/services/build_info.py
+++ b/SimWorks/apps/common/services/build_info.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 import os
 from pathlib import Path
 import tomllib
-from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 ORCHESTRAI_PACKAGE_NAME = "orchestrai"

--- a/SimWorks/config/ENVIRONMENT.md
+++ b/SimWorks/config/ENVIRONMENT.md
@@ -40,6 +40,7 @@ This project uses a single Django settings module and environment variables for 
 ## Site metadata
 - `SITE_NAME`
 - `SITE_ADMIN_NAME`, `SITE_ADMIN_EMAIL`
+- `APP_GIT_SHA` (optional backend commit SHA exposed by `/api/v1/build-info/`; `GIT_SHA` is also accepted as a fallback)
 
 ## Authentication / Social providers
 - `ACCOUNT_SIGNUP_FIELDS`

--- a/SimWorks/config/ENVIRONMENT.md
+++ b/SimWorks/config/ENVIRONMENT.md
@@ -40,7 +40,8 @@ This project uses a single Django settings module and environment variables for 
 ## Site metadata
 - `SITE_NAME`
 - `SITE_ADMIN_NAME`, `SITE_ADMIN_EMAIL`
-- `APP_GIT_SHA` (optional backend commit SHA exposed by `/api/v1/build-info/`; `GIT_SHA` is also accepted as a fallback)
+- `APP_GIT_SHA` (optional backend commit SHA exposed by `/api/v1/build-info/`; `GIT_SHA` is accepted as a fallback)
+- `APP_BUILD_TIME` (optional backend artifact build timestamp in UTC exposed by `/api/v1/build-info/`; `BUILD_TIME` is accepted as a fallback)
 
 ## Authentication / Social providers
 - `ACCOUNT_SIGNUP_FIELDS`

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -537,6 +537,29 @@
         ]
       }
     },
+    "/api/v1/build-info/": {
+      "get": {
+        "operationId": "api_v1_endpoints_build_info_build_info",
+        "summary": "Get build metadata",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildInfoOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns best-effort backend build metadata for app startup screens.",
+        "tags": [
+          "system"
+        ]
+      }
+    },
     "/api/v1/simulations/": {
       "get": {
         "operationId": "api_v1_endpoints_simulations_list_simulations",
@@ -4412,6 +4435,85 @@
           "cancel_url"
         ],
         "title": "CheckoutSessionIn",
+        "type": "object"
+      },
+      "BackendBuildInfoOut": {
+        "description": "Backend runtime metadata for startup display.",
+        "properties": {
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Installed backend package version",
+            "title": "Version"
+          },
+          "commit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Injected backend source commit SHA",
+            "title": "Commit"
+          },
+          "build_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Backend build timestamp when available",
+            "title": "Build Time"
+          }
+        },
+        "title": "BackendBuildInfoOut",
+        "type": "object"
+      },
+      "BuildInfoOut": {
+        "description": "Best-effort build metadata for the mobile splash screen.",
+        "properties": {
+          "backend": {
+            "$ref": "#/components/schemas/BackendBuildInfoOut"
+          },
+          "orchestrai": {
+            "$ref": "#/components/schemas/OrchestraiBuildInfoOut"
+          }
+        },
+        "required": [
+          "backend",
+          "orchestrai"
+        ],
+        "title": "BuildInfoOut",
+        "type": "object"
+      },
+      "OrchestraiBuildInfoOut": {
+        "description": "OrchestrAI package metadata for startup display.",
+        "properties": {
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Installed OrchestrAI package version",
+            "title": "Version"
+          }
+        },
+        "title": "OrchestraiBuildInfoOut",
         "type": "object"
       },
       "PaginatedResponse_SimulationOut_": {

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -4438,7 +4438,7 @@
         "type": "object"
       },
       "BackendBuildInfoOut": {
-        "description": "Backend runtime metadata for startup display.",
+        "description": "Backend artifact metadata for startup display.",
         "properties": {
           "version": {
             "anyOf": [

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -554,7 +554,7 @@
             }
           }
         },
-        "description": "Returns best-effort backend build metadata for app startup screens.",
+        "description": "Returns best-effort backend build metadata for app startup and debug screens.",
         "tags": [
           "system"
         ]
@@ -4473,7 +4473,7 @@
                 "type": "null"
               }
             ],
-            "description": "Backend build timestamp when available",
+            "description": "Backend artifact build timestamp in UTC when supplied by the build pipeline",
             "title": "Build Time"
           }
         },

--- a/tests/api/test_api_foundation.py
+++ b/tests/api/test_api_foundation.py
@@ -23,6 +23,13 @@ class TestAPIMount:
 
         assert response.status_code == 200
 
+    def test_build_info_endpoint_is_mounted(self):
+        """Build info endpoint responds at /api/v1/build-info/."""
+        client = Client()
+        response = client.get("/api/v1/build-info/")
+
+        assert response.status_code == 200
+
     def test_unknown_route_returns_404(self):
         """Unknown API routes return 404."""
         client = Client()

--- a/tests/api/test_build_info.py
+++ b/tests/api/test_build_info.py
@@ -1,0 +1,94 @@
+"""Tests for the public build info endpoint."""
+
+from importlib.metadata import PackageNotFoundError
+
+from django.test import Client
+import pytest
+
+
+@pytest.mark.django_db
+class TestBuildInfoEndpoint:
+    """Contract tests for /api/v1/build-info/."""
+
+    def test_build_info_happy_path(self, monkeypatch):
+        """Endpoint returns best-effort metadata when all sources exist."""
+        monkeypatch.setenv("APP_GIT_SHA", "abc1234")
+
+        def fake_safe_version(package_name: str) -> str | None:
+            if package_name == "MedSim":
+                return "0.10.2"
+            if package_name == "orchestrai":
+                return "0.5.1"
+            return None
+
+        monkeypatch.setattr(
+            "apps.common.services.build_info.safe_package_version",
+            fake_safe_version,
+        )
+
+        response = Client().get("/api/v1/build-info/")
+
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("application/json")
+        assert response.json() == {
+            "backend": {
+                "version": "0.10.2",
+                "commit": "abc1234",
+                "build_time": None,
+            },
+            "orchestrai": {
+                "version": "0.5.1",
+            },
+        }
+
+    def test_build_info_missing_commit_env_var(self, monkeypatch):
+        """Endpoint returns null commit when no build SHA was injected."""
+        monkeypatch.delenv("APP_GIT_SHA", raising=False)
+        monkeypatch.delenv("GIT_SHA", raising=False)
+        monkeypatch.setattr(
+            "apps.common.services.build_info.safe_package_version",
+            lambda package_name: "0.10.2" if package_name == "MedSim" else "0.5.1",
+        )
+
+        response = Client().get("/api/v1/build-info/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["backend"]["commit"] is None
+        assert data["backend"]["build_time"] is None
+
+    def test_build_info_missing_orchestrai_package_metadata(self, monkeypatch):
+        """Endpoint degrades gracefully when OrchestrAI metadata is unavailable."""
+        monkeypatch.setenv("APP_GIT_SHA", "abc1234")
+
+        def fake_version(package_name: str) -> str:
+            if package_name == "MedSim":
+                return "0.10.2"
+            if package_name == "orchestrai":
+                raise PackageNotFoundError(package_name)
+            raise AssertionError(f"Unexpected package lookup: {package_name}")
+
+        monkeypatch.setattr("apps.common.services.build_info.version", fake_version)
+
+        response = Client().get("/api/v1/build-info/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["backend"]["version"] == "0.10.2"
+        assert data["backend"]["commit"] == "abc1234"
+        assert data["orchestrai"]["version"] is None
+
+    def test_build_info_response_shape_always_present(self, monkeypatch):
+        """Endpoint keeps a stable JSON shape even when values are null."""
+        monkeypatch.delenv("APP_GIT_SHA", raising=False)
+        monkeypatch.delenv("GIT_SHA", raising=False)
+        monkeypatch.setattr("apps.common.services.build_info.safe_package_version", lambda _: None)
+
+        response = Client().get("/api/v1/build-info/")
+
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("application/json")
+        data = response.json()
+        assert set(data.keys()) == {"backend", "orchestrai"}
+        assert set(data["backend"].keys()) == {"version", "commit", "build_time"}
+        assert set(data["orchestrai"].keys()) == {"version"}

--- a/tests/api/test_build_info.py
+++ b/tests/api/test_build_info.py
@@ -5,6 +5,58 @@ from importlib.metadata import PackageNotFoundError
 from django.test import Client
 import pytest
 
+from apps.common.services import build_info as build_info_service
+
+
+@pytest.mark.django_db
+class TestBuildInfoHelpers:
+    """Helper-level tests for build metadata resolution."""
+
+    def test_backend_version_uses_canonical_project_name(self, monkeypatch, tmp_path):
+        """Backend version lookup should follow ``[project].name`` from pyproject metadata."""
+        pyproject_path = tmp_path / "pyproject.toml"
+        pyproject_path.write_text('[project]\nname = "BackendDist"\n')
+        monkeypatch.setattr(build_info_service, "PYPROJECT_TOML_PATH", pyproject_path)
+
+        looked_up_names: list[str] = []
+
+        def fake_version(package_name: str) -> str:
+            looked_up_names.append(package_name)
+            return "0.10.2"
+
+        monkeypatch.setattr(build_info_service, "version", fake_version)
+
+        assert build_info_service.get_backend_version() == "0.10.2"
+        assert looked_up_names == ["BackendDist"]
+
+    def test_commit_env_precedence_prefers_app_git_sha(self, monkeypatch):
+        """APP_GIT_SHA should win over GIT_SHA when both are present."""
+        monkeypatch.setenv("APP_GIT_SHA", "preferred-sha")
+        monkeypatch.setenv("GIT_SHA", "fallback-sha")
+
+        assert build_info_service.get_backend_commit() == "preferred-sha"
+
+    def test_build_time_env_precedence_prefers_app_build_time(self, monkeypatch):
+        """APP_BUILD_TIME should win over BUILD_TIME when both are present."""
+        monkeypatch.setenv("APP_BUILD_TIME", "2026-04-09T17:12:44Z")
+        monkeypatch.setenv("BUILD_TIME", "2026-04-09T12:00:00Z")
+
+        assert build_info_service.get_backend_build_time() == "2026-04-09T17:12:44Z"
+
+    def test_build_time_falls_back_to_build_time_env_var(self, monkeypatch):
+        """BUILD_TIME should be used when APP_BUILD_TIME is unset."""
+        monkeypatch.delenv("APP_BUILD_TIME", raising=False)
+        monkeypatch.setenv("BUILD_TIME", "2026-04-09T12:00:00Z")
+
+        assert build_info_service.get_backend_build_time() == "2026-04-09T12:00:00Z"
+
+    def test_build_time_returns_none_for_missing_or_blank_values(self, monkeypatch):
+        """Blank or missing build time env vars should resolve to None."""
+        monkeypatch.setenv("APP_BUILD_TIME", "   ")
+        monkeypatch.setenv("BUILD_TIME", "")
+
+        assert build_info_service.get_backend_build_time() is None
+
 
 @pytest.mark.django_db
 class TestBuildInfoEndpoint:
@@ -13,9 +65,14 @@ class TestBuildInfoEndpoint:
     def test_build_info_happy_path(self, monkeypatch):
         """Endpoint returns best-effort metadata when all sources exist."""
         monkeypatch.setenv("APP_GIT_SHA", "abc1234")
+        monkeypatch.setenv("APP_BUILD_TIME", "2026-04-09T17:12:44Z")
+        monkeypatch.setattr(
+            "apps.common.services.build_info.get_backend_package_name",
+            lambda: "backend-dist",
+        )
 
         def fake_safe_version(package_name: str) -> str | None:
-            if package_name == "MedSim":
+            if package_name == "backend-dist":
                 return "0.10.2"
             if package_name == "orchestrai":
                 return "0.5.1"
@@ -34,7 +91,7 @@ class TestBuildInfoEndpoint:
             "backend": {
                 "version": "0.10.2",
                 "commit": "abc1234",
-                "build_time": None,
+                "build_time": "2026-04-09T17:12:44Z",
             },
             "orchestrai": {
                 "version": "0.5.1",
@@ -45,9 +102,15 @@ class TestBuildInfoEndpoint:
         """Endpoint returns null commit when no build SHA was injected."""
         monkeypatch.delenv("APP_GIT_SHA", raising=False)
         monkeypatch.delenv("GIT_SHA", raising=False)
+        monkeypatch.delenv("APP_BUILD_TIME", raising=False)
+        monkeypatch.delenv("BUILD_TIME", raising=False)
+        monkeypatch.setattr(
+            "apps.common.services.build_info.get_backend_package_name",
+            lambda: "backend-dist",
+        )
         monkeypatch.setattr(
             "apps.common.services.build_info.safe_package_version",
-            lambda package_name: "0.10.2" if package_name == "MedSim" else "0.5.1",
+            lambda package_name: "0.10.2" if package_name == "backend-dist" else "0.5.1",
         )
 
         response = Client().get("/api/v1/build-info/")
@@ -60,9 +123,14 @@ class TestBuildInfoEndpoint:
     def test_build_info_missing_orchestrai_package_metadata(self, monkeypatch):
         """Endpoint degrades gracefully when OrchestrAI metadata is unavailable."""
         monkeypatch.setenv("APP_GIT_SHA", "abc1234")
+        monkeypatch.setenv("APP_BUILD_TIME", "2026-04-09T17:12:44Z")
+        monkeypatch.setattr(
+            "apps.common.services.build_info.get_backend_package_name",
+            lambda: "backend-dist",
+        )
 
         def fake_version(package_name: str) -> str:
-            if package_name == "MedSim":
+            if package_name == "backend-dist":
                 return "0.10.2"
             if package_name == "orchestrai":
                 raise PackageNotFoundError(package_name)
@@ -76,12 +144,33 @@ class TestBuildInfoEndpoint:
         data = response.json()
         assert data["backend"]["version"] == "0.10.2"
         assert data["backend"]["commit"] == "abc1234"
+        assert data["backend"]["build_time"] == "2026-04-09T17:12:44Z"
         assert data["orchestrai"]["version"] is None
+
+    def test_build_info_build_time_falls_back_to_build_time_env(self, monkeypatch):
+        """Endpoint should expose BUILD_TIME when APP_BUILD_TIME is unset."""
+        monkeypatch.delenv("APP_BUILD_TIME", raising=False)
+        monkeypatch.setenv("BUILD_TIME", "2026-04-09T17:12:44Z")
+        monkeypatch.setattr(
+            "apps.common.services.build_info.get_backend_package_name",
+            lambda: "backend-dist",
+        )
+        monkeypatch.setattr(
+            "apps.common.services.build_info.safe_package_version",
+            lambda package_name: "0.10.2" if package_name == "backend-dist" else "0.5.1",
+        )
+
+        response = Client().get("/api/v1/build-info/")
+
+        assert response.status_code == 200
+        assert response.json()["backend"]["build_time"] == "2026-04-09T17:12:44Z"
 
     def test_build_info_response_shape_always_present(self, monkeypatch):
         """Endpoint keeps a stable JSON shape even when values are null."""
         monkeypatch.delenv("APP_GIT_SHA", raising=False)
         monkeypatch.delenv("GIT_SHA", raising=False)
+        monkeypatch.delenv("APP_BUILD_TIME", raising=False)
+        monkeypatch.delenv("BUILD_TIME", raising=False)
         monkeypatch.setattr("apps.common.services.build_info.safe_package_version", lambda _: None)
 
         response = Client().get("/api/v1/build-info/")

--- a/tests/api/test_openapi.py
+++ b/tests/api/test_openapi.py
@@ -123,6 +123,7 @@ class TestOpenAPISchemaContent:
                 "/api/v1/health",
                 "/api/v1/health/auth",
                 "/api/v1/health/jwt",
+                "/api/v1/build-info/",
             ],
         )
 


### PR DESCRIPTION
## Summary
- add a public `GET /api/v1/build-info/` Django Ninja endpoint for splash-screen backend metadata
- add typed response schemas and a small common service to resolve backend version, commit SHA, and OrchestrAI version safely
- document `APP_GIT_SHA` support and update the committed OpenAPI schema

## Testing
- `uv run pytest tests/api/test_build_info.py tests/api/test_api_foundation.py tests/api/test_openapi.py -q`
- Result: `33 passed, 1 skipped`