### PR TITLE
Emit problem.updated after recommendation recompute for complete payload

### DIFF
--- a/SimWorks/api/v1/endpoints/trainerlab.py
+++ b/SimWorks/api/v1/endpoints/trainerlab.py
@@ -1604,21 +1604,6 @@ def _inject_event_core(
             idempotency_key=f"{event_type}:{domain_event.id}",
         )
 
-    if event_kind == "intervention" and getattr(domain_event, "_adjudication_result", None):
-        adjudication_result = domain_event._adjudication_result
-        refreshed_problem = Problem.objects.filter(pk=domain_event.target_problem_id).first()
-        if refreshed_problem is not None and adjudication_result.changed:
-            emit_domain_runtime_event(
-                session=session,
-                event_type=outbox_events.PATIENT_PROBLEM_UPDATED,
-                obj=refreshed_problem,
-                created_by=user,
-                correlation_id=correlation_id,
-                idempotency_key=(
-                    f"{outbox_events.PATIENT_PROBLEM_UPDATED}:"
-                    f"post-intervention:{refreshed_problem.id}:{domain_event.id}"
-                ),
-            )
     commit_non_ai_mutation_side_effects(
         session=session,
         event_kind=event_kind,
@@ -1626,6 +1611,31 @@ def _inject_event_core(
         worker_kind="manual_injection",
         domains=[event_kind],
     )
+
+    # Emit patient.problem.updated AFTER recompute_active_recommendations has run
+    # (inside commit_non_ai_mutation_side_effects above) so the payload includes the
+    # full post-adjudication recommendation state for the superseding problem.
+    # Recommendation events (removed/created) are emitted first by the recompute step;
+    # this problem event then carries the authoritative complete snapshot the iOS client
+    # can apply as a full overlay without waiting for the next /state/ poll.
+    if event_kind == "intervention":
+        _adj = getattr(domain_event, "_adjudication_result", None)
+        if _adj is not None and _adj.changed:
+            refreshed_problem = Problem.objects.filter(
+                pk=domain_event.target_problem_id
+            ).first()
+            if refreshed_problem is not None:
+                emit_domain_runtime_event(
+                    session=session,
+                    event_type=outbox_events.PATIENT_PROBLEM_UPDATED,
+                    obj=refreshed_problem,
+                    created_by=user,
+                    correlation_id=correlation_id,
+                    idempotency_key=(
+                        f"{outbox_events.PATIENT_PROBLEM_UPDATED}:"
+                        f"post-intervention:{refreshed_problem.id}:{domain_event.id}"
+                    ),
+                )
 
     # Guard: block runtime queueing if session is paused/locked — but
     # allow the domain record itself to be created (manual-edit rule).

--- a/SimWorks/api/v1/endpoints/trainerlab.py
+++ b/SimWorks/api/v1/endpoints/trainerlab.py
@@ -1621,9 +1621,7 @@ def _inject_event_core(
     if event_kind == "intervention":
         _adj = getattr(domain_event, "_adjudication_result", None)
         if _adj is not None and _adj.changed:
-            refreshed_problem = Problem.objects.filter(
-                pk=domain_event.target_problem_id
-            ).first()
+            refreshed_problem = Problem.objects.filter(pk=domain_event.target_problem_id).first()
             if refreshed_problem is not None:
                 emit_domain_runtime_event(
                     session=session,

--- a/SimWorks/apps/common/ws_auth.py
+++ b/SimWorks/apps/common/ws_auth.py
@@ -210,6 +210,16 @@ class JWTAuthMiddleware(BaseMiddleware):
                     has_account_header=has_account_header,
                     **request_context,
                 )
+            else:
+                logger.debug(
+                    "ws.auth.anonymous_fallback",
+                    path=path,
+                    had_bearer_token=False,
+                    reason="missing_bearer_token",
+                    header_names=header_names,
+                    has_account_header=has_account_header,
+                    **request_context,
+                )
 
         return await super().__call__(scope, receive, send)
 

--- a/tests/simulation/test_trainerlab_intervention_events.py
+++ b/tests/simulation/test_trainerlab_intervention_events.py
@@ -1,0 +1,470 @@
+"""Integration tests for post-adjudication domain event emission.
+
+Verifies that after a trainer injects an intervention:
+  1. patient.intervention.created is emitted immediately
+  2. patient.recommendedintervention.removed is emitted for any stale recs
+  3. patient.problem.updated is emitted with a complete payload that includes
+     the post-adjudication recommended_interventions list
+  4. /state/ reflects the adjudicated problem status without a further round-trip
+"""
+
+from contextlib import nullcontext
+from unittest.mock import patch
+
+from django.test import Client
+import pytest
+
+from api.v1.auth import create_access_token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal copies of the shared set from tests/api/test_trainerlab.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_role(db):
+    from apps.accounts.models import UserRole
+
+    return UserRole.objects.create(title="Intervention Events Test Role")
+
+
+@pytest.fixture
+def instructor_user(django_user_model, user_role):
+    return django_user_model.objects.create_user(
+        password="testpass123",
+        email="intervention-events-instructor@example.com",
+        role=user_role,
+    )
+
+
+@pytest.fixture
+def instructor_membership(instructor_user):
+    from apps.accounts.services import get_personal_account_for_user
+    from apps.billing.catalog import ProductCode
+    from apps.billing.models import Entitlement
+
+    account = get_personal_account_for_user(instructor_user)
+    return Entitlement.objects.create(
+        account=account,
+        source_type=Entitlement.SourceType.MANUAL,
+        source_ref="manual:trainerlab-go",
+        scope_type=Entitlement.ScopeType.USER,
+        subject_user=instructor_user,
+        product_code=ProductCode.TRAINERLAB_GO.value,
+        status=Entitlement.Status.ACTIVE,
+        portable_across_accounts=True,
+    )
+
+
+@pytest.fixture
+def auth_client(instructor_user, instructor_membership):
+    token = create_access_token(instructor_user)
+    client = Client()
+    client.defaults["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Shared request helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: Client, *, idempotency_key: str) -> dict:
+    from apps.trainerlab.services import complete_initial_scenario_generation
+
+    with patch(
+        "apps.trainerlab.services.enqueue_initial_scenario_generation",
+        return_value="test-call-id",
+    ):
+        response = client.post(
+            "/api/v1/trainerlab/simulations/",
+            data={
+                "scenario_spec": {"diagnosis": "GSW", "tick_interval_seconds": 60},
+                "directives": "",
+                "modifiers": [],
+            },
+            content_type="application/json",
+            HTTP_IDEMPOTENCY_KEY=idempotency_key,
+        )
+    assert response.status_code in (200, 201), response.content
+    payload = response.json()
+    complete_initial_scenario_generation(simulation_id=payload["simulation_id"])
+    return payload
+
+
+def _post_injury(client: Client, *, simulation_id: int, idempotency_key: str):
+    resp = client.post(
+        f"/api/v1/trainerlab/simulations/{simulation_id}/events/injuries/",
+        data={
+            "injury_location": "LUL",
+            "injury_kind": "GSW",
+            "injury_description": "GSW left thigh",
+            "description": "",
+        },
+        content_type="application/json",
+        HTTP_IDEMPOTENCY_KEY=idempotency_key,
+    )
+    assert resp.status_code == 200, resp.content
+    return resp
+
+
+def _post_problem(
+    client: Client,
+    *,
+    simulation_id: int,
+    cause_id: int,
+    idempotency_key: str,
+):
+    resp = client.post(
+        f"/api/v1/trainerlab/simulations/{simulation_id}/events/problems/",
+        data={
+            "cause_kind": "injury",
+            "cause_id": cause_id,
+            "kind": "hemorrhage",
+            "title": "Massive hemorrhage left thigh",
+            "march_category": "M",
+            "severity": "critical",
+            "anatomical_location": "Left thigh",
+        },
+        content_type="application/json",
+        HTTP_IDEMPOTENCY_KEY=idempotency_key,
+    )
+    assert resp.status_code == 200, resp.content
+    return resp
+
+
+def _post_tourniquet(
+    client: Client,
+    *,
+    simulation_id: int,
+    target_problem_id: int,
+    idempotency_key: str,
+    site_code: str = "LEFT_LEG",
+):
+    return client.post(
+        f"/api/v1/trainerlab/simulations/{simulation_id}/events/interventions/",
+        data={
+            "intervention_type": "tourniquet",
+            "site_code": site_code,
+            "target_problem_id": target_problem_id,
+            "status": "applied",
+            "effectiveness": "unknown",
+            "notes": "",
+            "details": {"kind": "tourniquet", "version": 1, "application_mode": "deliberate"},
+            "initiated_by_type": "user",
+        },
+        content_type="application/json",
+        HTTP_IDEMPOTENCY_KEY=idempotency_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared setup helper — creates session → injury → hemorrhage problem
+# and returns (simulation_id, injury, problem)
+# ---------------------------------------------------------------------------
+
+
+def _setup_hemorrhage(client: Client, *, prefix: str):
+    from apps.trainerlab.models import Injury, Problem
+
+    session = _create_session(client, idempotency_key=f"{prefix}-session")
+    sim_id = session["simulation_id"]
+
+    _post_injury(client, simulation_id=sim_id, idempotency_key=f"{prefix}-injury")
+    injury = Injury.objects.get(injury_description="GSW left thigh", simulation_id=sim_id)
+
+    _post_problem(
+        client, simulation_id=sim_id, cause_id=injury.id, idempotency_key=f"{prefix}-problem"
+    )
+    problem = Problem.objects.filter(simulation_id=sim_id, kind="hemorrhage").latest("timestamp")
+
+    return sim_id, injury, problem
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestInterventionAdjudicationEvents:
+    """Verify post-adjudication domain event emission for TrainerLab interventions."""
+
+    def test_effective_intervention_emits_intervention_created(self, auth_client):
+        """patient.intervention.created must be emitted for every successful intervention POST."""
+        from apps.common.models import OutboxEvent
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-created")
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-created-tq",
+        )
+        assert resp.status_code == 200
+
+        event = OutboxEvent.objects.filter(
+            simulation_id=sim_id,
+            event_type="patient.intervention.created",
+        ).first()
+        assert event is not None
+        assert event.payload["kind"] == "tourniquet"
+        assert event.payload["site_code"] == "LEFT_LEG"
+        assert event.payload["target_problem_previous_status"] == "active"
+        assert event.payload["target_problem_current_status"] == "controlled"
+        assert event.payload["adjudication_reason"] == "intervention_adjudicated"
+
+    def test_effective_intervention_emits_problem_updated_with_controlled_status(
+        self, auth_client
+    ):
+        """patient.problem.updated must reflect the adjudicated (controlled) status."""
+        from apps.common.models import OutboxEvent
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-prob-updated")
+        original_problem_id = problem.id
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-prob-updated-tq",
+        )
+        assert resp.status_code == 200
+
+        event = OutboxEvent.objects.filter(
+            simulation_id=sim_id,
+            event_type="patient.problem.updated",
+        ).first()
+        assert event is not None, "patient.problem.updated event must be emitted"
+
+        payload = event.payload
+        assert payload["status"] == "controlled"
+        assert payload["previous_status"] == "active"
+        assert payload["adjudication_reason"] == "intervention_adjudicated"
+        assert payload["triggering_intervention_id"] is not None
+        # The superseding problem has a new ID — the original problem is now inactive
+        assert payload["problem_id"] != original_problem_id
+
+    def test_problem_updated_payload_includes_recommended_interventions(self, auth_client):
+        """patient.problem.updated payload must contain a complete recommended_interventions
+        list — not an empty array — so the iOS overlay can render it without guessing.
+
+        The payload is emitted AFTER recompute_active_recommendations(), so the
+        superseding problem's new recommendation rows are already in the DB when
+        serialize_problem_snapshot() runs.
+        """
+        from apps.common.models import OutboxEvent
+        from apps.trainerlab.models import Problem
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-recs-in-payload")
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-recs-in-payload-tq",
+        )
+        assert resp.status_code == 200
+
+        event = OutboxEvent.objects.filter(
+            simulation_id=sim_id,
+            event_type="patient.problem.updated",
+        ).first()
+        assert event is not None
+
+        recs = event.payload.get("recommended_interventions")
+        assert isinstance(recs, list), "recommended_interventions must be a list in the payload"
+        assert len(recs) > 0, (
+            "recommended_interventions must not be empty — payload is emitted after recompute"
+        )
+
+        # Every nested recommendation must target the NEW superseding problem
+        new_problem = Problem.objects.get(pk=event.payload["problem_id"])
+        for rec in recs:
+            assert rec["target_problem_id"] == new_problem.id, (
+                "nested recommendations must reference the superseding problem, not the old one"
+            )
+
+    def test_effective_intervention_emits_recommendation_removed_for_old_problem(
+        self, auth_client
+    ):
+        """After adjudication, recommendations for the deactivated problem are removed.
+
+        patient.recommendedintervention.removed must be emitted for each stale
+        recommendation whose target_problem is now inactive.
+        """
+        from apps.common.models import OutboxEvent
+        from apps.trainerlab.models import Problem, RecommendedIntervention
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-rec-removed")
+        original_problem_id = problem.id
+
+        # After posting the problem, recompute_active_recommendations was already called
+        # and created rule-based recommendations (tourniquet + pressure_dressing for hemorrhage).
+        assert RecommendedIntervention.objects.filter(
+            simulation_id=sim_id, target_problem_id=original_problem_id, is_active=True
+        ).exists(), "rule-based recs must exist before the intervention"
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-rec-removed-tq",
+        )
+        assert resp.status_code == 200
+
+        removed_events = OutboxEvent.objects.filter(
+            simulation_id=sim_id,
+            event_type="patient.recommendedintervention.removed",
+        )
+        assert removed_events.exists(), (
+            "patient.recommendedintervention.removed must be emitted for old recs"
+        )
+        # All removal events must reference the original (now-inactive) problem
+        for ev in removed_events:
+            assert ev.payload["target_problem_id"] == original_problem_id
+
+    def test_intervention_event_emitted_before_problem_event(self, auth_client):
+        """patient.intervention.created must appear in the event stream before
+        patient.problem.updated — causal ordering must be preserved.
+        """
+        from apps.trainerlab.models import Problem, RuntimeEvent
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-ordering")
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-ordering-tq",
+        )
+        assert resp.status_code == 200
+
+        events = list(
+            RuntimeEvent.objects.filter(
+                simulation_id=sim_id,
+                event_type__in=[
+                    "patient.intervention.created",
+                    "patient.problem.updated",
+                ],
+            ).order_by("created_at")
+        )
+        event_types = [e.event_type for e in events]
+        assert "patient.intervention.created" in event_types
+        assert "patient.problem.updated" in event_types
+
+        intervention_pos = event_types.index("patient.intervention.created")
+        problem_pos = [i for i, t in enumerate(event_types) if t == "patient.problem.updated"][-1]
+        assert intervention_pos < problem_pos, (
+            "patient.intervention.created must precede patient.problem.updated in stream order"
+        )
+
+    def test_ineffective_intervention_does_not_emit_problem_updated(self, auth_client):
+        """When adjudication does not change the problem (wrong type), no
+        patient.problem.updated event should be emitted.
+        """
+        from apps.common.models import OutboxEvent
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-no-effect")
+
+        # chest_seal does not apply to hemorrhage — adjudication_reason will be
+        # "intervention_not_applicable_to_problem_kind", changed=False
+        resp = auth_client.post(
+            f"/api/v1/trainerlab/simulations/{sim_id}/events/interventions/",
+            data={
+                "intervention_type": "chest_seal",
+                "site_code": "LEFT_ANTERIOR_CHEST",
+                "target_problem_id": problem.id,
+                "status": "applied",
+                "effectiveness": "unknown",
+                "notes": "",
+                "details": {"kind": "chest_seal", "version": 1},
+                "initiated_by_type": "user",
+            },
+            content_type="application/json",
+            HTTP_IDEMPOTENCY_KEY="tq-no-effect-chest-seal",
+        )
+        assert resp.status_code == 200
+
+        assert OutboxEvent.objects.filter(
+            simulation_id=sim_id, event_type="patient.intervention.created"
+        ).exists()
+        assert not OutboxEvent.objects.filter(
+            simulation_id=sim_id, event_type="patient.problem.updated"
+        ).exists(), (
+            "patient.problem.updated must NOT be emitted when adjudication has no effect"
+        )
+
+    def test_state_reflects_controlled_problem_immediately_after_intervention(self, auth_client):
+        """/state/ must show the superseding (controlled) problem immediately after
+        the intervention POST — without requiring a second runtime tick.
+        """
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-state")
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-state-tq",
+        )
+        assert resp.status_code == 200
+
+        state = auth_client.get(
+            f"/api/v1/trainerlab/simulations/{sim_id}/state/"
+        ).json()
+
+        problems = state["scenario_snapshot"]["problems"]
+        problem_statuses = {p["problem_id"]: p["status"] for p in problems}
+
+        # The original active problem must be gone (it is now inactive)
+        assert problem.id not in problem_statuses, (
+            "The original hemorrhage problem must no longer appear in /state/ (it is now inactive)"
+        )
+
+        # A controlled hemorrhage problem must exist
+        controlled = [p for p in problems if p["status"] == "controlled"]
+        assert controlled, "/state/ must contain a controlled hemorrhage problem"
+        assert controlled[0]["kind"] == "hemorrhage"
+
+    def test_recommendation_created_for_superseding_problem(self, auth_client):
+        """After adjudication, a new recommendation must be created that targets the
+        superseding problem (not the original deactivated one).
+
+        patient.recommendedintervention.created is emitted as part of
+        recompute_active_recommendations() before the problem.updated event fires.
+        """
+        from apps.common.models import OutboxEvent
+        from apps.trainerlab.models import Problem
+
+        sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-rec-created")
+        original_problem_id = problem.id
+
+        resp = _post_tourniquet(
+            auth_client,
+            simulation_id=sim_id,
+            target_problem_id=problem.id,
+            idempotency_key="tq-rec-created-tq",
+        )
+        assert resp.status_code == 200
+
+        # Retrieve the new superseding problem ID from the problem.updated event
+        problem_event = OutboxEvent.objects.filter(
+            simulation_id=sim_id, event_type="patient.problem.updated"
+        ).first()
+        assert problem_event is not None
+        new_problem_id = problem_event.payload["problem_id"]
+        assert new_problem_id != original_problem_id
+
+        # There must be at least one created event targeting the NEW superseding problem
+        # (separate from the initial recommendation events emitted when the problem was first added)
+        created_for_new_problem = OutboxEvent.objects.filter(
+            simulation_id=sim_id,
+            event_type="patient.recommendedintervention.created",
+            payload__target_problem_id=new_problem_id,
+        )
+        assert created_for_new_problem.exists(), (
+            "patient.recommendedintervention.created must be emitted targeting the "
+            "superseding (controlled) problem after adjudication"
+        )

--- a/tests/simulation/test_trainerlab_intervention_events.py
+++ b/tests/simulation/test_trainerlab_intervention_events.py
@@ -216,9 +216,7 @@ class TestInterventionAdjudicationEvents:
         assert event.payload["target_problem_current_status"] == "controlled"
         assert event.payload["adjudication_reason"] == "intervention_adjudicated"
 
-    def test_effective_intervention_emits_problem_updated_with_controlled_status(
-        self, auth_client
-    ):
+    def test_effective_intervention_emits_problem_updated_with_controlled_status(self, auth_client):
         """patient.problem.updated must reflect the adjudicated (controlled) status."""
         from apps.common.models import OutboxEvent
 
@@ -287,9 +285,7 @@ class TestInterventionAdjudicationEvents:
                 "nested recommendations must reference the superseding problem, not the old one"
             )
 
-    def test_effective_intervention_emits_recommendation_removed_for_old_problem(
-        self, auth_client
-    ):
+    def test_effective_intervention_emits_recommendation_removed_for_old_problem(self, auth_client):
         """After adjudication, recommendations for the deactivated problem are removed.
 
         patient.recommendedintervention.removed must be emitted for each stale
@@ -393,9 +389,7 @@ class TestInterventionAdjudicationEvents:
         ).exists()
         assert not OutboxEvent.objects.filter(
             simulation_id=sim_id, event_type="patient.problem.updated"
-        ).exists(), (
-            "patient.problem.updated must NOT be emitted when adjudication has no effect"
-        )
+        ).exists(), "patient.problem.updated must NOT be emitted when adjudication has no effect"
 
     def test_state_reflects_controlled_problem_immediately_after_intervention(self, auth_client):
         """/state/ must show the superseding (controlled) problem immediately after
@@ -411,9 +405,7 @@ class TestInterventionAdjudicationEvents:
         )
         assert resp.status_code == 200
 
-        state = auth_client.get(
-            f"/api/v1/trainerlab/simulations/{sim_id}/state/"
-        ).json()
+        state = auth_client.get(f"/api/v1/trainerlab/simulations/{sim_id}/state/").json()
 
         problems = state["scenario_snapshot"]["problems"]
         problem_statuses = {p["problem_id"]: p["status"] for p in problems}

--- a/tests/simulation/test_trainerlab_intervention_events.py
+++ b/tests/simulation/test_trainerlab_intervention_events.py
@@ -343,7 +343,7 @@ class TestInterventionAdjudicationEvents:
                     "patient.intervention.created",
                     "patient.problem.updated",
                 ],
-            ).order_by("created_at")
+            ).order_by("created_at", "id")
         )
         event_types = [e.event_type for e in events]
         assert "patient.intervention.created" in event_types

--- a/tests/simulation/test_trainerlab_intervention_events.py
+++ b/tests/simulation/test_trainerlab_intervention_events.py
@@ -8,14 +8,12 @@ Verifies that after a trainer injects an intervention:
   4. /state/ reflects the adjudicated problem status without a further round-trip
 """
 
-from contextlib import nullcontext
 from unittest.mock import patch
 
 from django.test import Client
 import pytest
 
 from api.v1.auth import create_access_token
-
 
 # ---------------------------------------------------------------------------
 # Fixtures — minimal copies of the shared set from tests/api/test_trainerlab.py
@@ -292,7 +290,7 @@ class TestInterventionAdjudicationEvents:
         recommendation whose target_problem is now inactive.
         """
         from apps.common.models import OutboxEvent
-        from apps.trainerlab.models import Problem, RecommendedIntervention
+        from apps.trainerlab.models import RecommendedIntervention
 
         sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-rec-removed")
         original_problem_id = problem.id
@@ -326,7 +324,7 @@ class TestInterventionAdjudicationEvents:
         """patient.intervention.created must appear in the event stream before
         patient.problem.updated — causal ordering must be preserved.
         """
-        from apps.trainerlab.models import Problem, RuntimeEvent
+        from apps.trainerlab.models import RuntimeEvent
 
         sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-ordering")
 
@@ -428,7 +426,6 @@ class TestInterventionAdjudicationEvents:
         recompute_active_recommendations() before the problem.updated event fires.
         """
         from apps.common.models import OutboxEvent
-        from apps.trainerlab.models import Problem
 
         sim_id, _injury, problem = _setup_hemorrhage(auth_client, prefix="tq-rec-created")
         original_problem_id = problem.id


### PR DESCRIPTION
## Summary
Moves the emission of `patient.problem.updated` events to occur **after** recommendation recomputation, ensuring the event payload includes the complete post-adjudication recommended interventions list. This allows iOS clients to render the full overlay state immediately without waiting for a subsequent `/state/` poll.

## Key Changes
- **Reordered event emission timing**: Moved `patient.problem.updated` emission from before to after `commit_non_ai_mutation_side_effects()` (which triggers recommendation recomputation)
- **Ensures complete payload**: The problem snapshot now includes all newly-created recommendations for the superseding problem, not an empty array
- **Preserves causal ordering**: `patient.intervention.created` still emits first, followed by recommendation events (removed/created), then the complete `patient.problem.updated` snapshot
- **Added comprehensive integration tests**: New test suite (`test_trainerlab_intervention_events.py`) verifies:
  - Intervention created events are emitted
  - Problem updated events include non-empty recommended_interventions list
  - Recommendation removed events target the deactivated problem
  - Recommendation created events target the superseding problem
  - Event stream ordering is correct
  - `/state/` reflects adjudicated status immediately
  - Ineffective interventions don't emit problem updates

## Implementation Details
The change ensures that when an intervention adjudicates a problem (e.g., tourniquet controlling hemorrhage), the iOS client receives a single authoritative `patient.problem.updated` event with:
- The new superseding problem's ID and controlled status
- Complete list of applicable recommendations for that problem
- Adjudication metadata (reason, triggering intervention ID)

This eliminates the need for clients to poll `/state/` or wait for the next runtime tick to see the full recommendation state.

https://claude.ai/code/session_011qjRphQ7vfPD2uaAV29U1r