### PR TITLE
fix(email): switch SMTP defaults to SendGrid

### DIFF
--- a/SimWorks/apps/common/checks.py
+++ b/SimWorks/apps/common/checks.py
@@ -71,14 +71,14 @@ FEATURE_SETTING_CHECKS: list[tuple[Callable[[], bool], str, str, str, str]] = [
         "EMAIL_HOST_USER",
         "config.E006",
         "EMAIL_HOST_USER is missing while SMTP email backend is enabled.",
-        "Set EMAIL_HOST_USER to the full iCloud Mail address used for SMTP auth.",
+        "Set EMAIL_HOST_USER to `apikey` for SendGrid SMTP.",
     ),
     (
         _smtp_enabled,
         "EMAIL_HOST_PASSWORD",
         "config.E007",
         "EMAIL_HOST_PASSWORD is missing while SMTP email backend is enabled.",
-        "Set EMAIL_HOST_PASSWORD to an Apple app-specific password.",
+        "Set EMAIL_HOST_PASSWORD to the SendGrid API key.",
     ),
 ]
 
@@ -172,7 +172,7 @@ def check_email_configuration(app_configs, **kwargs):
             errors.append(
                 Error(
                     "EMAIL_HOST_USER is required when SMTP backend is active.",
-                    hint="Set EMAIL_HOST_USER to the full iCloud Mail address.",
+                    hint="Set EMAIL_HOST_USER to `apikey` for SendGrid SMTP.",
                     id="config.E015",
                 )
             )
@@ -180,8 +180,18 @@ def check_email_configuration(app_configs, **kwargs):
             errors.append(
                 Error(
                     "EMAIL_HOST_PASSWORD is required when SMTP backend is active.",
-                    hint="Set EMAIL_HOST_PASSWORD to an Apple app-specific password.",
+                    hint="Set EMAIL_HOST_PASSWORD to the SendGrid API key.",
                     id="config.E020",
+                )
+            )
+        email_host = str(getattr(settings, "EMAIL_HOST", "")).strip().lower()
+        email_host_user = str(getattr(settings, "EMAIL_HOST_USER", "")).strip()
+        if email_host == "smtp.sendgrid.net" and email_host_user and email_host_user != "apikey":
+            warnings.append(
+                Warning(
+                    "EMAIL_HOST_USER is not the expected SendGrid SMTP username.",
+                    hint="SendGrid SMTP generally requires EMAIL_HOST_USER=apikey.",
+                    id="config.W002",
                 )
             )
 

--- a/SimWorks/config/ENVIRONMENT.md
+++ b/SimWorks/config/ENVIRONMENT.md
@@ -29,12 +29,12 @@ This project uses a single Django settings module and environment variables for 
 ## Email / transactional messaging
 - `EMAIL_USE_CONSOLE_BACKEND` (defaults true only in local/dev-style environments)
 - `EMAIL_BACKEND` (defaults to console in local/dev, SMTP backend elsewhere)
-- `EMAIL_HOST` (default: `smtp.mail.me.com`)
+- `EMAIL_HOST` (default: `smtp.sendgrid.net`)
 - `EMAIL_PORT` (default: `587`)
 - `EMAIL_USE_TLS` (default: `true`)
 - `EMAIL_USE_SSL` (default: `false`)
-- `EMAIL_HOST_USER` (full iCloud Mail address used for SMTP auth)
-- `EMAIL_HOST_PASSWORD` (Apple app-specific password)
+- `EMAIL_HOST_USER` (default: `apikey` when SMTP backend is active)
+- `EMAIL_HOST_PASSWORD` (SendGrid API key)
 - `EMAIL_ENVIRONMENT_NAME` (e.g. `local`, `staging`, `production`)
 - `EMAIL_BASE_URL` (defaults to `https://medsim.jackfruitco.com` for production-like, `https://medsim-staging.jackfruitco.com` for staging)
 - `DEFAULT_FROM_EMAIL` (default: `MedSim by Jackfruit <noreply@jackfruitco.com>`)
@@ -44,7 +44,25 @@ This project uses a single Django settings module and environment variables for 
 - `EMAIL_STAGING_SUBJECT_PREFIX` (default: `[STAGING]`)
 - `ACCOUNT_DEFAULT_HTTP_PROTOCOL` (default: `https`)
 
-Current low-volume production-intended transport is iCloud SMTP (temporary for private beta). The app-level email abstraction remains provider-agnostic to keep future migration to Postmark as a backend/config swap.
+Current low-volume staging/production transport is SendGrid SMTP through Django's SMTP backend abstraction. The app-level email service and auth-email templates remain provider-agnostic so future provider migration stays mostly a backend/config swap.
+
+Staging SendGrid SMTP values:
+
+- `EMAIL_ENVIRONMENT_NAME=staging`
+- `EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend`
+- `EMAIL_HOST=smtp.sendgrid.net`
+- `EMAIL_PORT=587`
+- `EMAIL_USE_TLS=true`
+- `EMAIL_USE_SSL=false`
+- `EMAIL_HOST_USER=apikey`
+- `EMAIL_HOST_PASSWORD=<SendGrid API key>`
+- `EMAIL_BASE_URL=https://medsim-staging.jackfruitco.com`
+
+Sender identity defaults may be omitted if the defaults are acceptable:
+
+- `DEFAULT_FROM_EMAIL="MedSim by Jackfruit <noreply@jackfruitco.com>"`
+- `EMAIL_REPLY_TO=support@jackfruitco.com`
+- `SERVER_EMAIL=errors@jackfruitco.com`
 
 ## Tasks / Redis / Celery / Rate limits
 - `REDIS_HOSTNAME`, `REDIS_PORT`, `REDIS_PASSWORD`

--- a/SimWorks/config/email_settings.py
+++ b/SimWorks/config/email_settings.py
@@ -1,7 +1,7 @@
 """Email and transactional messaging settings.
 
-Temporary backend choice: iCloud SMTP for low-volume/private beta.
-Keep this module provider-replaceable so switching to Postmark later is mostly
+Current backend choice: SendGrid SMTP for low-volume staging/production sending.
+Keep this module provider-replaceable so future provider changes are mostly
 an EMAIL_BACKEND/settings change rather than app-code changes.
 """
 
@@ -35,11 +35,12 @@ EMAIL_BACKEND = os.getenv(
     CONSOLE_BACKEND if EMAIL_USE_CONSOLE_BACKEND else SMTP_BACKEND,
 )
 
-EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.mail.me.com")
+EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.sendgrid.net")
 EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
 EMAIL_USE_TLS = bool_from_env("EMAIL_USE_TLS", default=True)
 EMAIL_USE_SSL = bool_from_env("EMAIL_USE_SSL", default=False)
-EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+_default_email_host_user = "apikey" if EMAIL_BACKEND == SMTP_BACKEND else ""
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", _default_email_host_user)
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
 
 DEFAULT_FROM_EMAIL = os.getenv(

--- a/tests/common/test_email_checks.py
+++ b/tests/common/test_email_checks.py
@@ -40,6 +40,8 @@ def test_email_checks_error_for_missing_smtp_credentials():
 
     assert "config.E015" in _ids(results)
     assert "config.E020" in _ids(results)
+    assert any("SendGrid SMTP" in str(result.hint) for result in results)
+    assert any("SendGrid API key" in str(result.hint) for result in results)
 
 
 @override_settings(
@@ -60,3 +62,21 @@ def test_email_checks_validate_sender_identity_and_warn_on_non_approved_host():
     assert "config.E017" in _ids(results)
     assert "config.E018" in _ids(results)
     assert any(isinstance(result, Warning) and result.id == "config.W001" for result in results)
+
+
+@override_settings(
+    DEBUG=False,
+    EMAIL_ENVIRONMENT_NAME="production",
+    EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
+    EMAIL_HOST="smtp.sendgrid.net",
+    EMAIL_HOST_USER="user@example.com",
+    EMAIL_HOST_PASSWORD="sendgrid-api-key",
+    DEFAULT_FROM_EMAIL="MedSim by Jackfruit <noreply@jackfruitco.com>",
+    EMAIL_REPLY_TO="support@jackfruitco.com",
+    SERVER_EMAIL="errors@jackfruitco.com",
+    EMAIL_BASE_URL="https://medsim.jackfruitco.com",
+)
+def test_email_checks_warn_for_sendgrid_smtp_username_override():
+    results = checks.check_email_configuration(None)
+
+    assert any(isinstance(result, Warning) and result.id == "config.W002" for result in results)

--- a/tests/common/test_email_settings_module.py
+++ b/tests/common/test_email_settings_module.py
@@ -11,6 +11,10 @@ def reload_email_settings(monkeypatch):
             "EMAIL_ENVIRONMENT_NAME",
             "EMAIL_USE_CONSOLE_BACKEND",
             "EMAIL_BACKEND",
+            "EMAIL_HOST",
+            "EMAIL_PORT",
+            "EMAIL_USE_TLS",
+            "EMAIL_USE_SSL",
             "EMAIL_HOST_USER",
             "EMAIL_HOST_PASSWORD",
             "EMAIL_BASE_URL",
@@ -41,20 +45,35 @@ def test_email_settings_defaults_to_console_in_local_debug(reload_email_settings
     assert settings_mod.EMAIL_BACKEND == "django.core.mail.backends.console.EmailBackend"
 
 
-def test_email_settings_defaults_to_smtp_in_staging_when_credentials_present(reload_email_settings):
+def test_email_settings_defaults_to_sendgrid_smtp_in_staging(reload_email_settings):
     settings_mod = reload_email_settings(
         {
             "DJANGO_DEBUG": "false",
             "EMAIL_ENVIRONMENT_NAME": "staging",
-            "EMAIL_HOST_USER": "noreply@icloud.example",
-            "EMAIL_HOST_PASSWORD": "app-specific-password",
+            "EMAIL_HOST_PASSWORD": "sendgrid-api-key",
         }
     )
 
     assert settings_mod.EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend"
-    assert settings_mod.EMAIL_HOST == "smtp.mail.me.com"
+    assert settings_mod.EMAIL_HOST == "smtp.sendgrid.net"
     assert settings_mod.EMAIL_PORT == 587
     assert settings_mod.EMAIL_USE_TLS is True
+    assert settings_mod.EMAIL_USE_SSL is False
+    assert settings_mod.EMAIL_HOST_USER == "apikey"
+
+
+def test_email_settings_preserves_explicit_smtp_username_override(reload_email_settings):
+    settings_mod = reload_email_settings(
+        {
+            "DJANGO_DEBUG": "false",
+            "EMAIL_ENVIRONMENT_NAME": "staging",
+            "EMAIL_HOST_USER": "custom-user",
+            "EMAIL_HOST_PASSWORD": "sendgrid-api-key",
+        }
+    )
+
+    assert settings_mod.EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend"
+    assert settings_mod.EMAIL_HOST_USER == "custom-user"
 
 
 def test_email_settings_flags_missing_smtp_credentials_outside_local(reload_email_settings):


### PR DESCRIPTION
## Summary
- Update transactional email defaults from iCloud SMTP to SendGrid SMTP while keeping Django’s SMTP backend abstraction
- Refresh deployment checks and environment docs with SendGrid-specific credentials and warnings
- Adjust email settings tests to cover the new defaults and username behavior

## Testing
- `uv run pytest tests/common/test_email_settings_module.py tests/common/test_email_checks.py tests/common/test_email_service.py tests/accounts/test_account_email_adapter.py`
- `uv run python SimWorks/manage.py check`
- `git diff --check`