### PR TITLE
simcore/orca: ground initial feedback in canonical transcript

### DIFF
--- a/SimWorks/apps/common/orca/instructions/feedback.yaml
+++ b/SimWorks/apps/common/orca/instructions/feedback.yaml
@@ -9,6 +9,7 @@ instructions:
       - You are an expert medical educator providing constructive debrief feedback.
       - Be specific, actionable, and evidence-based.
       - Balance strengths with clear improvement opportunities.
+      - All coaching must remain grounded in the supplied simulation record and transcript.
 
       ### Response Schema
       - Follow the active feedback service schema exactly.

--- a/SimWorks/apps/simcore/orca/instructions/feedback.yaml
+++ b/SimWorks/apps/simcore/orca/instructions/feedback.yaml
@@ -6,10 +6,23 @@ instructions:
     order: 0
     instruction: |
       Evaluate the completed simulation and produce structured initial feedback.
-      Assess diagnostic accuracy, treatment-plan appropriateness, patient experience (0-5),
-      and a concise narrative debrief.
-      The narrative should include: correct diagnosis and treatment plan, key differentials,
-      important missed history questions (if any), 1-2 sustains, and 1-2 improves.
+
+      You MUST base your feedback exclusively on the actual simulation transcript provided.
+      Do not invent actions, questions, treatments, diagnoses, findings, or omissions not present
+      in the simulation record. Do not provide generic feedback.
+
+      ### Narrative Requirements
+      - Open the narrative (overall_feedback) by clearly identifying the correct diagnosis and
+        correct treatment plan in the first 1-2 sentences.
+      - Assess: diagnostic accuracy, treatment-plan appropriateness, patient experience (0-5).
+      - The narrative must:
+        - Reference specific learner actions, omissions, or decision points from the transcript.
+        - Identify missed history questions ONLY if they were demonstrably absent from the transcript.
+        - Include 1-2 sustains grounded in what the learner actually did.
+        - Include 1-2 improves grounded in specific gaps or errors in the transcript.
+        - Avoid generic educator boilerplate not supported by the record.
+      - If transcript or context is incomplete, briefly acknowledge that and make the most
+        conservative possible assessment.
 
       ### Response Schema
       - Use GenerateInitialSimulationFeedback.

--- a/SimWorks/apps/simcore/orca/services/feedback.py
+++ b/SimWorks/apps/simcore/orca/services/feedback.py
@@ -4,16 +4,18 @@
 import logging
 from typing import ClassVar
 
-from orchestrai_django.components.services import DjangoBaseService
+from asgiref.sync import sync_to_async
+from orchestrai_django.components.services import DjangoBaseService, PreviousResponseMixin
 from orchestrai_django.decorators import orca
 
+from apps.common.utils import Formatter
 from ..mixins import FeedbackMixin  # Identity mixin for component discovery
 
 logger = logging.getLogger(__name__)
 
 
 @orca.service
-class GenerateInitialFeedback(FeedbackMixin, DjangoBaseService):
+class GenerateInitialFeedback(PreviousResponseMixin, FeedbackMixin, DjangoBaseService):
     """Generate the initial patient feedback using Pydantic AI."""
 
     instruction_refs: ClassVar[list[str]] = [
@@ -27,6 +29,74 @@ class GenerateInitialFeedback(FeedbackMixin, DjangoBaseService):
     from apps.simcore.orca.schemas import GenerateInitialSimulationFeedback as _Schema
 
     response_schema = _Schema
+
+    async def _aprepare_context(self) -> None:
+        """Ground feedback in the canonical simulation transcript.
+
+        Provider response continuity (PreviousResponseMixin) is supplemental;
+        transcript is the canonical ground truth for feedback grounding.
+        """
+        # Chain mixin: lets PreviousResponseMixin set previous_response_id as supplement
+        if hasattr(super(), "_aprepare_context"):
+            await super()._aprepare_context()
+
+        # Respect explicit caller-provided user_message
+        if self.context.get("user_message"):
+            return
+
+        simulation_id = self.context.get("simulation_id")
+
+        try:
+            from apps.simcore.models import Simulation
+
+            sim = await Simulation.objects.aget(pk=simulation_id)
+        except Exception as exc:
+            logger.warning(
+                "[feedback] simulation %s not found, transcript unavailable: %s",
+                simulation_id,
+                exc,
+            )
+            self.context["user_message"] = (
+                "The simulation transcript is unavailable (simulation not found). "
+                "State this and provide the most conservative assessment possible."
+            )
+            return
+
+        history = await sync_to_async(sim.history)()
+        messages = [entry for entry in history if entry.get("content")]
+
+        logger.info(
+            "[feedback] simulation=%s messages_loaded=%d has_previous_response=%s",
+            simulation_id,
+            len(messages),
+            bool(self.context.get("previous_response_id")),
+        )
+
+        transcript = Formatter(messages).render("openai_sim_transcript")
+        self.context["transcript"] = transcript
+
+        if not transcript:
+            logger.warning(
+                "[feedback] simulation=%s transcript is empty, no messages to ground on",
+                simulation_id,
+            )
+            self.context["user_message"] = (
+                "The simulation transcript is unavailable or contains no messages. "
+                "State this and provide the most conservative assessment possible."
+            )
+            return
+
+        logger.info(
+            "[feedback] simulation=%s transcript_length=%d",
+            simulation_id,
+            len(transcript),
+        )
+        self.context["user_message"] = (
+            "Evaluate the following completed simulation. "
+            "Base your feedback exclusively on this transcript — "
+            "do not invent actions, questions, or omissions not present in the record.\n\n"
+            f"### Simulation Transcript\n{transcript}"
+        )
 
 
 @orca.service

--- a/SimWorks/apps/simcore/orca/services/feedback.py
+++ b/SimWorks/apps/simcore/orca/services/feedback.py
@@ -5,10 +5,11 @@ import logging
 from typing import ClassVar
 
 from asgiref.sync import sync_to_async
+
+from apps.common.utils import Formatter
 from orchestrai_django.components.services import DjangoBaseService, PreviousResponseMixin
 from orchestrai_django.decorators import orca
 
-from apps.common.utils import Formatter
 from ..mixins import FeedbackMixin  # Identity mixin for component discovery
 
 logger = logging.getLogger(__name__)

--- a/tests/simulation/test_feedback_services.py
+++ b/tests/simulation/test_feedback_services.py
@@ -1,0 +1,234 @@
+"""Unit tests for GenerateInitialFeedback transcript grounding.
+
+Validates:
+- Service prepares transcript context from canonical simulation messages
+- Empty-transcript path sets an explicit fallback user_message
+- Grounded user_message contains actual transcript content
+- FeedbackInitialInstruction contains required grounding language
+"""
+
+import pathlib
+import types
+
+import pytest
+
+from apps.simcore.orca.services.feedback import GenerateInitialFeedback
+
+
+# ---------------------------------------------------------------------------
+# Helpers / Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_history(*pairs):
+    """Build list of history dicts matching the chatlab history provider format."""
+    return [
+        {"role": role, "sender": sender, "content": content, "timestamp": None}
+        for role, sender, content in pairs
+    ]
+
+
+def _make_mock_sim(history_data):
+    """Return a lightweight mock simulation object."""
+    sim = types.SimpleNamespace()
+    sim.history = lambda _format=None: history_data
+    return sim
+
+
+def _patch_simulation(monkeypatch, sim_obj):
+    """Monkeypatch Simulation.objects.aget to return sim_obj."""
+    class _Manager:
+        async def aget(self, **_kwargs):
+            return sim_obj
+
+    class _FakeSim:
+        objects = _Manager()
+
+    import apps.simcore.orca.services.feedback as feedback_module
+    monkeypatch.setattr(feedback_module, "Simulation", _FakeSim, raising=False)
+
+    # Also patch the import inside _aprepare_context (late import path)
+    import sys
+    fake_simcore = types.ModuleType("apps.simcore.models")
+    fake_simcore.Simulation = _FakeSim
+    monkeypatch.setitem(sys.modules, "apps.simcore.models", fake_simcore)
+
+
+# ---------------------------------------------------------------------------
+# Test A — Service prepares transcript context from messages
+# ---------------------------------------------------------------------------
+
+class TestPrepareTranscriptContext:
+    @pytest.mark.asyncio
+    async def test_transcript_and_user_message_set_from_history(self, monkeypatch):
+        history = _make_history(
+            ("A", "Patient", "I have chest pain."),
+            ("U", "Learner", "How long have you had it?"),
+            ("A", "Patient", "About an hour."),
+        )
+        sim = _make_mock_sim(history)
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 42})
+        await service._aprepare_context()
+
+        assert service.context.get("transcript"), "transcript must be set and non-empty"
+        assert service.context.get("user_message"), "user_message must be set and non-empty"
+
+    @pytest.mark.asyncio
+    async def test_transcript_contains_message_content(self, monkeypatch):
+        history = _make_history(
+            ("A", "Patient", "I have chest pain."),
+            ("U", "Learner", "How long have you had it?"),
+        )
+        sim = _make_mock_sim(history)
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 42})
+        await service._aprepare_context()
+
+        transcript = service.context.get("transcript", "")
+        assert "chest pain" in transcript
+        assert "How long" in transcript
+
+    @pytest.mark.asyncio
+    async def test_user_message_references_simulation_or_transcript(self, monkeypatch):
+        history = _make_history(("A", "Patient", "Hello."), ("U", "Learner", "Hi there."))
+        sim = _make_mock_sim(history)
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 42})
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "").lower()
+        assert "simulation" in user_msg or "transcript" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_messages_are_chronologically_included(self, monkeypatch):
+        history = _make_history(
+            ("U", "Learner", "First message"),
+            ("A", "Patient", "Second message"),
+            ("U", "Learner", "Third message"),
+        )
+        sim = _make_mock_sim(history)
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 42})
+        await service._aprepare_context()
+
+        transcript = service.context.get("transcript", "")
+        assert transcript.index("First") < transcript.index("Second") < transcript.index("Third")
+
+
+# ---------------------------------------------------------------------------
+# Test B — Empty transcript handled gracefully
+# ---------------------------------------------------------------------------
+
+class TestEmptyTranscriptFallback:
+    @pytest.mark.asyncio
+    async def test_empty_history_sets_fallback_user_message(self, monkeypatch):
+        sim = _make_mock_sim([])
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 99})
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "").lower()
+        assert "unavailable" in user_msg or "no messages" in user_msg or "incomplete" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_empty_history_does_not_crash(self, monkeypatch):
+        sim = _make_mock_sim([])
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 99})
+        # Must not raise
+        await service._aprepare_context()
+
+    @pytest.mark.asyncio
+    async def test_empty_content_messages_are_filtered(self, monkeypatch):
+        history = [
+            {"role": "A", "sender": "Patient", "content": "", "timestamp": None},
+            {"role": "U", "sender": "Learner", "content": None, "timestamp": None},
+        ]
+        sim = _make_mock_sim(history)
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 99})
+        await service._aprepare_context()
+
+        # All content was empty — should hit the empty-transcript fallback
+        user_msg = service.context.get("user_message", "").lower()
+        assert "unavailable" in user_msg or "no messages" in user_msg or "incomplete" in user_msg
+
+
+# ---------------------------------------------------------------------------
+# Test C — Grounding regression: actual transcript content reaches user_message
+# ---------------------------------------------------------------------------
+
+class TestGroundingRegression:
+    @pytest.mark.asyncio
+    async def test_specific_clinical_content_appears_in_user_message(self, monkeypatch):
+        history = _make_history(
+            ("U", "Learner", "Do you have any allergies?"),
+            ("A", "Patient", "I am allergic to penicillin."),
+            ("U", "Learner", "I am giving you aspirin."),
+        )
+        sim = _make_mock_sim(history)
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 7})
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "")
+        assert "aspirin" in user_msg, "user_message must contain grounded transcript content"
+        assert "penicillin" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_explicit_caller_user_message_is_not_overwritten(self, monkeypatch):
+        sim = _make_mock_sim(_make_history(("A", "Patient", "Hello.")))
+        _patch_simulation(monkeypatch, sim)
+
+        caller_msg = "Custom caller-provided evaluation prompt."
+        service = GenerateInitialFeedback(
+            context={"simulation_id": 7, "user_message": caller_msg}
+        )
+        await service._aprepare_context()
+
+        assert service.context["user_message"] == caller_msg
+
+
+# ---------------------------------------------------------------------------
+# Test D — Instruction regression: grounding language present in YAML
+# ---------------------------------------------------------------------------
+
+class TestInstructionGroundingLanguage:
+    def _load_instruction_text(self):
+        yaml_path = (
+            pathlib.Path(__file__).parents[2]
+            / "SimWorks/apps/simcore/orca/instructions/feedback.yaml"
+        )
+        return yaml_path.read_text()
+
+    def test_instruction_requires_actual_simulation_transcript(self):
+        text = self._load_instruction_text()
+        assert "simulation transcript" in text.lower(), (
+            "FeedbackInitialInstruction must reference 'simulation transcript'"
+        )
+
+    def test_instruction_prohibits_invention(self):
+        text = self._load_instruction_text()
+        assert "do not invent" in text.lower(), (
+            "FeedbackInitialInstruction must say 'Do not invent'"
+        )
+
+    def test_instruction_requires_specific_learner_actions(self):
+        text = self._load_instruction_text()
+        assert "specific learner" in text.lower() or "reference specific" in text.lower(), (
+            "FeedbackInitialInstruction must require reference to specific learner actions"
+        )
+
+    def test_instruction_requires_diagnosis_first_in_narrative(self):
+        text = self._load_instruction_text()
+        assert "first 1-2 sentences" in text.lower(), (
+            "FeedbackInitialInstruction must require correct diagnosis in first 1-2 sentences"
+        )

--- a/tests/simulation/test_feedback_services.py
+++ b/tests/simulation/test_feedback_services.py
@@ -14,10 +14,10 @@ import pytest
 
 from apps.simcore.orca.services.feedback import GenerateInitialFeedback
 
-
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
 # ---------------------------------------------------------------------------
+
 
 def _make_history(*pairs):
     """Build list of history dicts matching the chatlab history provider format."""
@@ -36,6 +36,7 @@ def _make_mock_sim(history_data):
 
 def _patch_simulation(monkeypatch, sim_obj):
     """Monkeypatch Simulation.objects.aget to return sim_obj."""
+
     class _Manager:
         async def aget(self, **_kwargs):
             return sim_obj
@@ -44,10 +45,12 @@ def _patch_simulation(monkeypatch, sim_obj):
         objects = _Manager()
 
     import apps.simcore.orca.services.feedback as feedback_module
+
     monkeypatch.setattr(feedback_module, "Simulation", _FakeSim, raising=False)
 
     # Also patch the import inside _aprepare_context (late import path)
     import sys
+
     fake_simcore = types.ModuleType("apps.simcore.models")
     fake_simcore.Simulation = _FakeSim
     monkeypatch.setitem(sys.modules, "apps.simcore.models", fake_simcore)
@@ -56,6 +59,7 @@ def _patch_simulation(monkeypatch, sim_obj):
 # ---------------------------------------------------------------------------
 # Test A — Service prepares transcript context from messages
 # ---------------------------------------------------------------------------
+
 
 class TestPrepareTranscriptContext:
     @pytest.mark.asyncio
@@ -123,6 +127,7 @@ class TestPrepareTranscriptContext:
 # Test B — Empty transcript handled gracefully
 # ---------------------------------------------------------------------------
 
+
 class TestEmptyTranscriptFallback:
     @pytest.mark.asyncio
     async def test_empty_history_sets_fallback_user_message(self, monkeypatch):
@@ -165,6 +170,7 @@ class TestEmptyTranscriptFallback:
 # Test C — Grounding regression: actual transcript content reaches user_message
 # ---------------------------------------------------------------------------
 
+
 class TestGroundingRegression:
     @pytest.mark.asyncio
     async def test_specific_clinical_content_appears_in_user_message(self, monkeypatch):
@@ -189,9 +195,7 @@ class TestGroundingRegression:
         _patch_simulation(monkeypatch, sim)
 
         caller_msg = "Custom caller-provided evaluation prompt."
-        service = GenerateInitialFeedback(
-            context={"simulation_id": 7, "user_message": caller_msg}
-        )
+        service = GenerateInitialFeedback(context={"simulation_id": 7, "user_message": caller_msg})
         await service._aprepare_context()
 
         assert service.context["user_message"] == caller_msg
@@ -200,6 +204,7 @@ class TestGroundingRegression:
 # ---------------------------------------------------------------------------
 # Test D — Instruction regression: grounding language present in YAML
 # ---------------------------------------------------------------------------
+
 
 class TestInstructionGroundingLanguage:
     def _load_instruction_text(self):


### PR DESCRIPTION
Patches GenerateInitialFeedback so it explicitly loads the simulation
transcript from the DB via the history registry before invoking the model.

- Adds _aprepare_context() that calls sim.history(), filters empty entries,
  renders a readable transcript via the openai_sim_transcript formatter, and
  injects it into context["user_message"] so the model has concrete grounding.
- Adds PreviousResponseMixin for supplemental provider-side continuity;
  transcript remains the canonical ground truth.
- Logs simulation_id, message count, transcript length, and previous-response
  presence so grounding failures are visible in service logs.
- Respects an explicit caller-provided user_message (no silent override).
- Empty/missing transcript sets an explicit fallback user_message instead of
  silently allowing hallucination.

https://claude.ai/code/session_01TQFTx66ECECdfMmRVrzLCw