### PR TITLE
feat(accounts): add SimWorks-styled allauth layout overrides

### DIFF
--- a/SimWorks/templates/account/verification_sent.html
+++ b/SimWorks/templates/account/verification_sent.html
@@ -1,0 +1,25 @@
+{% extends "allauth/layouts/entrance.html" %}
+{% load i18n %}
+
+{% block head_title %}Check Your Email — {{ SITE_NAME }}{% endblock %}
+
+{% block heading %}
+  <h1 class="text-3xl font-bold text-content mb-6 text-center">Check Your Email</h1>
+{% endblock %}
+
+{% block inner_content %}
+  <div class="text-center mb-6">
+    <span class="iconify text-5xl text-jckfrt-olive" data-icon="mdi:email-check-outline"></span>
+  </div>
+
+  <p class="text-content-secondary text-center mb-4">
+    We sent a verification link to <strong>{{ user.email }}</strong>.
+    Click the link in that email to activate your account before continuing.
+  </p>
+
+  <p class="text-sm text-content-secondary text-center">
+    Didn't receive it? Check your spam folder. If it still hasn't arrived,
+    <a href="{% url 'account_login' %}" class="text-jckfrt-olive hover:underline">return to login</a>
+    and sign in once it does.
+  </p>
+{% endblock %}

--- a/SimWorks/templates/account/verification_sent.html
+++ b/SimWorks/templates/account/verification_sent.html
@@ -9,7 +9,7 @@
 
 {% block inner_content %}
   <div class="text-center mb-6">
-    <span class="iconify text-5xl text-jckfrt-olive" data-icon="mdi:email-check-outline"></span>
+    <span class="iconify text-4xl text-jckfrt-olive" data-icon="mdi:email-check-outline"></span>
   </div>
 
   <p class="text-content-secondary text-center mb-4">

--- a/SimWorks/templates/allauth/layouts/base.html
+++ b/SimWorks/templates/allauth/layouts/base.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% block head_title %}{{ SITE_NAME }}{% endblock %}{% endblock %}

--- a/SimWorks/templates/allauth/layouts/entrance.html
+++ b/SimWorks/templates/allauth/layouts/entrance.html
@@ -1,0 +1,22 @@
+{% extends "allauth/layouts/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="tw-root">
+  <div class="w-full max-w-md md:max-w-xl lg:max-w-2xl mx-auto mt-8 bg-surface-alt border border-border rounded-lg shadow-lg p-6 md:p-8">
+
+    {% block heading %}{% endblock %}
+
+    {% if messages %}
+      {% for message in messages %}
+        <div class="bg-blue-50 border border-blue-200 text-blue-700 px-4 py-3 rounded mb-4" role="alert">
+          {{ message }}
+        </div>
+      {% endfor %}
+    {% endif %}
+
+    {% block inner_content %}{% endblock %}
+
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Override allauth/layouts/base.html and allauth/layouts/entrance.html so
any allauth page that falls back to the layout chain (notably
verification_sent) renders inside the SimWorks base shell with full nav,
CSS, and the standard auth card instead of unstyled allauth defaults.

Add account/verification_sent.html using those layouts — thin template
that only contributes the page-specific copy and email icon.

No new CSS added; all classes reuse existing tailwind/theme tokens from
the login/signup card pattern.

https://claude.ai/code/session_01N4doqqz3duHn8Eus8foWJz