### PR TITLE
Stabilize flaky patient instruction resolution test

### DIFF
--- a/tests/chatlab/test_patient_services.py
+++ b/tests/chatlab/test_patient_services.py
@@ -11,7 +11,6 @@ import pytest
 import yaml
 
 from apps.chatlab.orca.instructions import (
-    PatientNameInstruction,
     PatientRecentScenarioHistoryInstruction,
     patient as patient_instruction_module,
 )
@@ -146,7 +145,7 @@ class TestGenerateInitialResponseService:
             context={"simulation_id": 1},
         )
 
-        assert PatientNameInstruction in service._instruction_classes
+        assert "PatientNameInstruction" in _instruction_names(service)
 
     def test_safety_instruction_blocks_out_of_character_admission(self):
         service = GenerateInitialResponse(context={"simulation_id": 1})

--- a/tests/chatlab/test_patient_services.py
+++ b/tests/chatlab/test_patient_services.py
@@ -127,8 +127,9 @@ class TestGenerateInitialResponseService:
 
     def test_service_collects_instruction_classes(self):
         service = GenerateInitialResponse(context={"simulation_id": 1})
-        assert PatientNameInstruction in service._instruction_classes
-        assert PatientRecentScenarioHistoryInstruction in service._instruction_classes
+        names = _instruction_names(service)
+        assert "PatientNameInstruction" in names
+        assert "PatientRecentScenarioHistoryInstruction" in names
 
     def test_resolves_expected_instruction_names_in_order(self):
         service = GenerateInitialResponse(context={"simulation_id": 1})


### PR DESCRIPTION
### Motivation
- The test was brittle because it asserted class identity for instructions that can be re-exported or re-imported, producing duplicate class objects and false negatives; asserting resolved instruction names is robust to import/reload identity mismatches.

### Description
- Update `tests/chatlab/test_patient_services.py` in `TestGenerateInitialResponseService.test_service_collects_instruction_classes` to use `names = _instruction_names(service)` and assert that `"PatientNameInstruction"` and `"PatientRecentScenarioHistoryInstruction"` are present instead of asserting class object membership.

### Testing
- Attempted to run the targeted test via `uv run pytest tests/chatlab/test_patient_services.py::TestGenerateInitialResponseService::test_service_collects_instruction_classes`, but execution was blocked by the local Python interpreter configuration (`.python-version` requests `3.14.3`, which is not installed), so the automated test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a416f5848333b00ba1f1f627f379)