### PR TITLE
Submit logout via POST from header and mobile nav

### DIFF
--- a/SimWorks/templates/partials/header.html
+++ b/SimWorks/templates/partials/header.html
@@ -80,10 +80,13 @@
                                 <span class="iconify" data-icon="mdi:email-outline"></span>
                                 Email Settings
                             </a>
-                            <a href="{% url 'account_logout' %}" class="flex min-h-11 items-center gap-2 border-t border-border px-3 py-2 text-sm font-semibold text-red-700 transition-colors hover:bg-red-50">
-                                <span class="iconify" data-icon="mdi:logout"></span>
-                                Logout
-                            </a>
+                            <form method="post" action="{% url 'account_logout' %}" class="border-t border-border">
+                                {% csrf_token %}
+                                <button type="submit" class="flex min-h-11 w-full items-center gap-2 px-3 py-2 text-left text-sm font-semibold text-red-700 transition-colors hover:bg-red-50">
+                                    <span class="iconify" data-icon="mdi:logout"></span>
+                                    Logout
+                                </button>
+                            </form>
                         </div>
                     </div>
                 {% else %}
@@ -142,10 +145,13 @@
                         <span class="iconify" data-icon="mdi:email-outline"></span>
                         Email Settings
                     </a>
-                    <a href="{% url 'account_logout' %}" class="flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold text-red-700 transition-colors hover:bg-red-50" @click="mobileOpen = false">
-                        <span class="iconify" data-icon="mdi:logout"></span>
-                        Logout
-                    </a>
+                    <form method="post" action="{% url 'account_logout' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="flex min-h-11 w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-semibold text-red-700 transition-colors hover:bg-red-50" @click="mobileOpen = false">
+                            <span class="iconify" data-icon="mdi:logout"></span>
+                            Logout
+                        </button>
+                    </form>
                 {% else %}
                     <a href="{% url 'account_login' %}" class="flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-content transition-colors hover:bg-surface-alt" @click="mobileOpen = false">
                         <span class="iconify" data-icon="mdi:login-variant"></span>


### PR DESCRIPTION
### Motivation
- Remove the extra allauth logout confirmation by having the header/mobile logout control submit a `POST` directly to the allauth logout endpoint while preserving POST-only semantics.

### Description
- Replaced the `href="{% url 'account_logout' %}"` anchor logout controls in `SimWorks/templates/partials/header.html` (desktop account dropdown and mobile nav) with real HTML forms using `method="post"`, `action="{% url 'account_logout' %}"`, `{% csrf_token %}`, and a styled submit `button` that preserves the existing visual classes and Alpine `@click` behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a3f705d88333aec802b4f72a1265)