### PR TITLE
Fix ChatLab async simulation auth check triggering SynchronousOnlyOperation

### DIFF
--- a/SimWorks/apps/common/decorators.py
+++ b/SimWorks/apps/common/decorators.py
@@ -78,7 +78,9 @@ def simulation_required(kwarg_name: str = "simulation_id", owner_required: bool 
                 if (
                     owner_required
                     and request.user.is_authenticated
-                    and not can_access_simulation_in_request(request.user, simulation, request)
+                    and not await sync_to_async(can_access_simulation_in_request)(
+                        request.user, simulation, request
+                    )
                 ):
                     return HttpResponseForbidden("This isn't your simulation.")
                 request.simulation = simulation


### PR DESCRIPTION
### Motivation
- Prevent `SynchronousOnlyOperation` raised when the async `simulation_required` wrapper invoked sync ORM-backed logic (`can_access_simulation_in_request`) directly in an async view.

### Description
- In the async branch of `simulation_required` (`SimWorks/apps/common/decorators.py`) call `can_access_simulation_in_request(...)` via `await sync_to_async(...)` to avoid synchronous DB access from the async context.

### Testing
- Ran `python3 -m py_compile SimWorks/apps/common/decorators.py` which succeeded, attempted `uv run python manage.py check` which failed due to local `pyenv` interpreter mismatch, and attempted `UV_PYTHON=3.14.0 uv run python manage.py check` which bootstrapped but failed during Django startup due to upstream Pydantic/Python 3.14 beta compatibility issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a407f8c883339b6fcec0e9bf952c)