### PR TITLE
fix(db): Postgres data mount path for PG 18+

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -73,7 +73,7 @@ services:
     restart: always
     user: postgres
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB
       - POSTGRES_USER


### PR DESCRIPTION
This change is correct for Postgres 18+.

The official image changed `PGDATA` to a version-specific path (`/var/lib/postgresql/18/docker` for 18.x) and changed the declared volume root to `/var/lib/postgresql`. Mounting `/var/lib/postgresql/data` can leave the active data directory outside the persisted volume, which explains the fresh `initdb` on redeploy.

This should fix persistence going forward. We should still inspect the existing staging volume before redeploy in case data exists under the old layout and needs manual recovery/migration.