### PR TITLE
Add optional_int_from_env helper and improve env var parsing

### DIFF
--- a/SimWorks/config/settings.py
+++ b/SimWorks/config/settings.py
@@ -71,7 +71,7 @@ from .security_settings import (
     SESSION_COOKIE_SECURE,
     USE_X_FORWARDED_HOST,
 )
-from .settings_parsers import bool_from_env, int_from_env
+from .settings_parsers import bool_from_env, int_from_env, optional_int_from_env
 from .task_settings import (
     CELERY_ACCEPT_CONTENT,
     CELERY_BEAT_SCHEDULER,
@@ -225,16 +225,10 @@ TRAINERLAB_RUNTIME_MAX_PROMPT_TOKENS = int_from_env(
     default=7000,
     minimum=1000,
 )
-_trainerlab_runtime_max_output_tokens = os.getenv("TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS")
-if _trainerlab_runtime_max_output_tokens is None:
-    TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS = None
-else:
-    TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS = int(_trainerlab_runtime_max_output_tokens)
-    if TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS < 128:
-        raise ValueError(
-            "Environment variable TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS must be >= 128, "
-            f"got: {TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS}"
-        )
+TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS = optional_int_from_env(
+    "TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS",
+    minimum=128,
+)
 TRAINERLAB_RUNTIME_MAX_BATCH_REASONS = int_from_env(
     "TRAINERLAB_RUNTIME_MAX_BATCH_REASONS",
     default=8,

--- a/SimWorks/config/settings_parsers.py
+++ b/SimWorks/config/settings_parsers.py
@@ -24,7 +24,7 @@ def csv_from_env(name: str, default: list[str] | None = None) -> list[str]:
 
 def int_from_env(name: str, default: int, *, minimum: int | None = None) -> int:
     value = os.getenv(name)
-    if value is None:
+    if value is None or value.strip() == "":
         result = default
     else:
         try:
@@ -34,6 +34,22 @@ def int_from_env(name: str, default: int, *, minimum: int | None = None) -> int:
                 f"Environment variable {name} must be an integer, got: {value!r}"
             ) from exc
 
+    if minimum is not None and result < minimum:
+        raise ValueError(f"Environment variable {name} must be >= {minimum}, got: {result}")
+    return result
+
+
+def optional_int_from_env(name: str, *, minimum: int | None = None) -> int | None:
+    """Return int if the env var is set to a non-blank value, otherwise None."""
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return None
+    try:
+        result = int(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"Environment variable {name} must be an integer, got: {value!r}"
+        ) from exc
     if minimum is not None and result < minimum:
         raise ValueError(f"Environment variable {name} must be >= {minimum}, got: {result}")
     return result

--- a/SimWorks/config/settings_parsers.py
+++ b/SimWorks/config/settings_parsers.py
@@ -47,9 +47,7 @@ def optional_int_from_env(name: str, *, minimum: int | None = None) -> int | Non
     try:
         result = int(value)
     except ValueError as exc:
-        raise ValueError(
-            f"Environment variable {name} must be an integer, got: {value!r}"
-        ) from exc
+        raise ValueError(f"Environment variable {name} must be an integer, got: {value!r}") from exc
     if minimum is not None and result < minimum:
         raise ValueError(f"Environment variable {name} must be >= {minimum}, got: {result}")
     return result

--- a/tests/test_settings_parsers.py
+++ b/tests/test_settings_parsers.py
@@ -1,0 +1,79 @@
+"""Tests for config/settings_parsers.py env-var helpers."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load settings_parsers directly to avoid triggering config/__init__.py (Celery init).
+_parsers_path = Path(__file__).resolve().parents[1] / "SimWorks" / "config" / "settings_parsers.py"
+_spec = importlib.util.spec_from_file_location("settings_parsers", _parsers_path)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+int_from_env = _mod.int_from_env
+optional_int_from_env = _mod.optional_int_from_env
+
+
+class TestIntFromEnv:
+    def test_missing_returns_default(self, monkeypatch):
+        monkeypatch.delenv("_TEST_INT", raising=False)
+        assert int_from_env("_TEST_INT", default=42) == 42
+
+    def test_blank_string_returns_default(self, monkeypatch):
+        monkeypatch.setenv("_TEST_INT", "")
+        assert int_from_env("_TEST_INT", default=42) == 42
+
+    def test_whitespace_only_returns_default(self, monkeypatch):
+        monkeypatch.setenv("_TEST_INT", "   ")
+        assert int_from_env("_TEST_INT", default=42) == 42
+
+    def test_valid_integer(self, monkeypatch):
+        monkeypatch.setenv("_TEST_INT", "7")
+        assert int_from_env("_TEST_INT", default=0) == 7
+
+    def test_junk_raises_value_error(self, monkeypatch):
+        monkeypatch.setenv("_TEST_INT", "abc")
+        with pytest.raises(ValueError, match="_TEST_INT"):
+            int_from_env("_TEST_INT", default=0)
+
+    def test_minimum_enforced(self, monkeypatch):
+        monkeypatch.setenv("_TEST_INT", "0")
+        with pytest.raises(ValueError, match="_TEST_INT"):
+            int_from_env("_TEST_INT", default=0, minimum=1)
+
+    def test_minimum_not_violated(self, monkeypatch):
+        monkeypatch.setenv("_TEST_INT", "5")
+        assert int_from_env("_TEST_INT", default=0, minimum=1) == 5
+
+
+class TestOptionalIntFromEnv:
+    def test_missing_returns_none(self, monkeypatch):
+        monkeypatch.delenv("_TEST_OPT_INT", raising=False)
+        assert optional_int_from_env("_TEST_OPT_INT") is None
+
+    def test_blank_string_returns_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_OPT_INT", "")
+        assert optional_int_from_env("_TEST_OPT_INT") is None
+
+    def test_whitespace_only_returns_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_OPT_INT", "   ")
+        assert optional_int_from_env("_TEST_OPT_INT") is None
+
+    def test_valid_integer(self, monkeypatch):
+        monkeypatch.setenv("_TEST_OPT_INT", "256")
+        assert optional_int_from_env("_TEST_OPT_INT") == 256
+
+    def test_junk_raises_value_error(self, monkeypatch):
+        monkeypatch.setenv("_TEST_OPT_INT", "abc")
+        with pytest.raises(ValueError, match="_TEST_OPT_INT"):
+            optional_int_from_env("_TEST_OPT_INT")
+
+    def test_minimum_enforced(self, monkeypatch):
+        monkeypatch.setenv("_TEST_OPT_INT", "64")
+        with pytest.raises(ValueError, match="_TEST_OPT_INT"):
+            optional_int_from_env("_TEST_OPT_INT", minimum=128)
+
+    def test_minimum_not_violated(self, monkeypatch):
+        monkeypatch.setenv("_TEST_OPT_INT", "128")
+        assert optional_int_from_env("_TEST_OPT_INT", minimum=128) == 128


### PR DESCRIPTION
## Summary
This PR adds a new `optional_int_from_env` helper function to handle optional integer environment variables, and improves the existing `int_from_env` function to properly handle blank/whitespace-only values. The changes include comprehensive test coverage for both functions.

## Key Changes
- **New function `optional_int_from_env`**: Returns an integer if the environment variable is set to a non-blank value, otherwise returns `None`. Supports optional minimum value validation.
- **Improved `int_from_env`**: Now treats blank and whitespace-only strings as missing values (returns default) instead of attempting to parse them.
- **Refactored settings.py**: Replaced manual environment variable parsing logic for `TRAINERLAB_RUNTIME_MAX_OUTPUT_TOKENS` with a call to `optional_int_from_env`, reducing code duplication and improving maintainability.
- **Comprehensive test suite**: Added 14 test cases covering both functions with scenarios including missing variables, blank/whitespace values, valid integers, invalid input, and minimum value enforcement.

## Implementation Details
- Both functions treat `None`, empty strings, and whitespace-only strings identically as "not set"
- Both functions support optional `minimum` parameter for value validation
- Both functions raise `ValueError` with descriptive messages when validation fails
- Tests use direct module loading to avoid triggering Celery initialization through `config/__init__.py`

https://claude.ai/code/session_017L4DuYrqfwUBN89MCgdmXa