### PR TITLE
Fix ChatLab simulation scoping to ChatLab sessions

### DIFF
--- a/SimWorks/api/v1/endpoints/_lab_order_submission.py
+++ b/SimWorks/api/v1/endpoints/_lab_order_submission.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 from ninja.errors import HttpError
 
 from api.v1.schemas.lab_orders import LabOrdersOut
-from api.v1.utils import get_simulation_for_user
+from api.v1.utils import get_chatlab_simulation_for_user
 from apps.chatlab.access import require_lab_access as require_chatlab_access
 from config.logging import get_logger
 
@@ -23,7 +23,7 @@ def submit_lab_orders_request(
 
     require_chatlab_access(request.auth, request=request)
 
-    simulation = get_simulation_for_user(simulation_id, request.auth, request=request)
+    simulation = get_chatlab_simulation_for_user(simulation_id, request.auth, request=request)
     if simulation.status != Simulation.SimulationStatus.IN_PROGRESS:
         raise HttpError(400, "Lab orders can only be submitted for in-progress simulations")
 

--- a/SimWorks/api/v1/endpoints/conversations.py
+++ b/SimWorks/api/v1/endpoints/conversations.py
@@ -15,7 +15,7 @@ from api.v1.schemas.conversations import (
     ConversationOut,
     conversation_to_out,
 )
-from api.v1.utils import get_simulation_for_user
+from api.v1.utils import get_chatlab_simulation_for_user
 from apps.chatlab.access import require_lab_access as require_chatlab_access
 from apps.common.outbox import event_types as outbox_events
 from apps.common.ratelimit import api_rate_limit
@@ -87,7 +87,7 @@ def list_conversations(
     from apps.simcore.models import Conversation
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     conversations = (
         Conversation.objects.filter(simulation=sim, is_archived=False)
@@ -117,7 +117,7 @@ def create_conversation(
     from apps.simcore.models import Conversation, ConversationType
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     # Resolve conversation type
     try:
@@ -181,7 +181,7 @@ def get_conversation(
     from apps.simcore.models import Conversation
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     try:
         conv = (

--- a/SimWorks/api/v1/endpoints/events.py
+++ b/SimWorks/api/v1/endpoints/events.py
@@ -6,7 +6,7 @@ from ninja.errors import HttpError
 
 from api.v1.auth import JWTAuth
 from api.v1.schemas.events import EventEnvelope, EventReplayResponse
-from api.v1.utils import get_simulation_for_user
+from api.v1.utils import get_chatlab_simulation_for_user
 from apps.chatlab.access import require_lab_access as require_chatlab_access
 from apps.chatlab.media_payloads import build_message_media_payload, payload_message_id
 from apps.chatlab.models import Message
@@ -58,7 +58,7 @@ def list_events(
     """List durable events for explicit ChatLab replay."""
     _require_chatlab_access(request)
     user = request.auth
-    get_simulation_for_user(simulation_id, user, request=request)
+    get_chatlab_simulation_for_user(simulation_id, user, request=request)
     anchor_found: bool | None = None
 
     queryset = order_outbox_queryset(

--- a/SimWorks/api/v1/endpoints/messages.py
+++ b/SimWorks/api/v1/endpoints/messages.py
@@ -17,7 +17,7 @@ from api.v1.schemas.messages import (
     MessageOut,
     message_to_out,
 )
-from api.v1.utils import get_simulation_for_user
+from api.v1.utils import get_chatlab_simulation_for_user
 from apps.chatlab.access import require_lab_access as require_chatlab_access
 from apps.common.outbox import event_types as outbox_events
 from apps.common.ratelimit import api_rate_limit, message_rate_limit
@@ -332,7 +332,7 @@ def list_messages(
     from apps.chatlab.models import Message
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     # Base queryset with select_related to avoid N+1 on conversation_type
     queryset = (
@@ -404,7 +404,7 @@ def create_message(
     from apps.chatlab.models import Message, RoleChoices
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     # ── Guard: ChatLab send-lock check ──────────────────────────────
     _guard_chat_send(sim)
@@ -481,7 +481,7 @@ def retry_message(
     from apps.chatlab.models import Message
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     # ── Guard: ChatLab send-lock check ──────────────────────────────
     _guard_chat_send(sim)
@@ -557,7 +557,7 @@ def get_message(
     from apps.chatlab.models import Message
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     try:
         message = (
@@ -588,7 +588,7 @@ def mark_message_read(
     from apps.chatlab.models import Message
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     try:
         message = (

--- a/SimWorks/api/v1/endpoints/simulations.py
+++ b/SimWorks/api/v1/endpoints/simulations.py
@@ -22,8 +22,8 @@ from api.v1.schemas.simulations import (
 )
 from api.v1.utils import (
     get_account_for_request,
-    get_simulation_for_user,
-    get_simulation_queryset_for_request,
+    get_chatlab_simulation_for_user,
+    get_chatlab_simulation_queryset_for_request,
 )
 from apps.chatlab.access import require_lab_access as require_chatlab_access
 from apps.common.outbox import event_types as outbox_events
@@ -124,7 +124,7 @@ def list_simulations(
 
     user = request.auth
     queryset = (
-        get_simulation_queryset_for_request(request, user)
+        get_chatlab_simulation_queryset_for_request(request, user)
         .select_related("chatlab_session")
         .order_by("-start_timestamp", "-pk")
     )
@@ -197,6 +197,7 @@ def list_simulations(
 def create_simulation(request: HttpRequest, body: SimulationCreate) -> SimulationOut:
     """Create a new simulation."""
     _require_chatlab_access(request)
+    from apps.chatlab.models import ChatSession
     from apps.simcore.models import Simulation
 
     user = request.auth
@@ -214,6 +215,7 @@ def create_simulation(request: HttpRequest, body: SimulationCreate) -> Simulatio
         sim_patient_full_name=body.patient_full_name,
         time_limit=time_limit,
     )
+    ChatSession.objects.create(simulation=sim)
 
     logger.info(
         "simulation.created",
@@ -262,7 +264,7 @@ def get_simulation(request: HttpRequest, simulation_id: int) -> SimulationOut:
     """Get a specific simulation by ID."""
     _require_chatlab_access(request)
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     return simulation_to_out(sim)
 
@@ -278,7 +280,7 @@ def end_simulation(request: HttpRequest, simulation_id: int) -> SimulationEndRes
     """End a simulation."""
     _require_chatlab_access(request)
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     if sim.is_complete:
         raise HttpError(400, "Simulation is already ended")
@@ -307,7 +309,7 @@ def retry_initial(request: HttpRequest, simulation_id: int) -> tuple[int, Simula
     from apps.simcore.models import Conversation, ConversationType, Simulation
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     if not _sim_has_chatlab_session(sim):
         raise HttpError(400, "Initial generation retry is only available for ChatLab simulations")
@@ -363,7 +365,7 @@ def retry_feedback(request: HttpRequest, simulation_id: int) -> tuple[int, Simul
     from apps.simcore.models import Simulation
 
     user = request.auth
-    sim = get_simulation_for_user(simulation_id, user, request=request)
+    sim = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     if sim.status not in {
         Simulation.SimulationStatus.COMPLETED,

--- a/SimWorks/api/v1/endpoints/simulations.py
+++ b/SimWorks/api/v1/endpoints/simulations.py
@@ -23,7 +23,6 @@ from api.v1.schemas.simulations import (
 from api.v1.utils import (
     get_account_for_request,
     get_chatlab_simulation_for_user,
-    get_chatlab_simulation_queryset_for_request,
 )
 from apps.chatlab.access import require_lab_access as require_chatlab_access
 from apps.common.outbox import event_types as outbox_events
@@ -33,6 +32,7 @@ from apps.common.retries import (
     has_user_retries_remaining,
     is_simulation_initial_generation_retryable,
 )
+from apps.simcore.access import get_chatlab_simulation_queryset_for_request
 from config.logging import get_logger
 
 logger = get_logger(__name__)

--- a/SimWorks/api/v1/endpoints/tools.py
+++ b/SimWorks/api/v1/endpoints/tools.py
@@ -11,7 +11,7 @@ from api.v1.auth import DualAuth
 from api.v1.endpoints._lab_order_submission import submit_lab_orders_request
 from api.v1.schemas.lab_orders import LabOrdersOut
 from api.v1.schemas.tools import SignOrdersIn, ToolListResponse, ToolOut
-from api.v1.utils import get_simulation_for_user
+from api.v1.utils import get_chatlab_simulation_for_user
 from apps.common.ratelimit import api_rate_limit
 
 router = Router(tags=["tools"], auth=DualAuth())
@@ -44,7 +44,7 @@ def list_simulation_tools(
     from apps.simcore.tools import list_tools
 
     user = request.auth
-    simulation = get_simulation_for_user(simulation_id, user, request=request)
+    simulation = get_chatlab_simulation_for_user(simulation_id, user, request=request)
 
     if names:
         tool_names = [name.lower() for name in names]
@@ -73,7 +73,7 @@ def get_simulation_tool(
     tool_name: str,
 ) -> ToolOut:
     user = request.auth
-    simulation = get_simulation_for_user(simulation_id, user, request=request)
+    simulation = get_chatlab_simulation_for_user(simulation_id, user, request=request)
     tool_class = _resolve_tool_or_404(tool_name)
     return ToolOut(**tool_class(simulation).to_dict())
 

--- a/SimWorks/api/v1/utils.py
+++ b/SimWorks/api/v1/utils.py
@@ -31,6 +31,12 @@ def get_simulation_queryset_for_request(request, user):
     return queryset.filter(user=user)
 
 
+def get_chatlab_simulation_queryset_for_request(request, user):
+    return get_simulation_queryset_for_request(request, user).filter(
+        chatlab_session__isnull=False
+    )
+
+
 def get_simulation_for_user(simulation_id: int, user, request=None):
     """Get a simulation, ensuring the user has access.
 
@@ -63,3 +69,24 @@ def get_simulation_for_user(simulation_id: int, user, request=None):
     if simulation.account_id and not can_view_simulation(user, simulation):
         raise HttpError(404, "Simulation not found")
     return simulation
+
+
+def get_chatlab_simulation_for_user(simulation_id: int, user, request=None):
+    """Get a ChatLab-backed simulation, ensuring the user has access."""
+    from apps.simcore.models import Simulation
+
+    if request is not None:
+        queryset = get_chatlab_simulation_queryset_for_request(request, user)
+        try:
+            return queryset.get(pk=simulation_id)
+        except Simulation.DoesNotExist as err:
+            raise HttpError(404, "Simulation not found") from err
+
+    try:
+        return (
+            Simulation.objects.select_related("account", "chatlab_session")
+            .filter(user=user, chatlab_session__isnull=False)
+            .get(pk=simulation_id)
+        )
+    except Simulation.DoesNotExist as err:
+        raise HttpError(404, "Simulation not found") from err

--- a/SimWorks/api/v1/utils.py
+++ b/SimWorks/api/v1/utils.py
@@ -5,6 +5,7 @@ from ninja.errors import HttpError
 
 from apps.accounts.context import resolve_request_account
 from apps.accounts.permissions import can_view_account_runs, can_view_simulation
+from apps.simcore.access import get_chatlab_simulation_queryset_for_request
 
 
 def get_account_for_request(request, user):
@@ -29,12 +30,6 @@ def get_simulation_queryset_for_request(request, user):
     if can_view_account_runs(user, account):
         return queryset
     return queryset.filter(user=user)
-
-
-def get_chatlab_simulation_queryset_for_request(request, user):
-    return get_simulation_queryset_for_request(request, user).filter(
-        chatlab_session__isnull=False
-    )
 
 
 def get_simulation_for_user(simulation_id: int, user, request=None):

--- a/SimWorks/apps/chatlab/views.py
+++ b/SimWorks/apps/chatlab/views.py
@@ -16,7 +16,7 @@ from apps.chatlab.utils import (
     create_new_simulation,
     maybe_start_simulation,
 )
-from apps.common.decorators import resolve_user, simulation_required
+from apps.common.decorators import resolve_user
 from apps.common.models import OutboxEvent
 from apps.common.outbox.outbox import order_outbox_queryset
 from apps.common.retries import (
@@ -25,8 +25,8 @@ from apps.common.retries import (
 )
 from apps.common.watch import build_watch_page_context, build_watch_service_calls_context
 from apps.simcore.access import (
-    can_access_simulation_in_request,
-    get_simulation_queryset_for_request,
+    can_access_chatlab_simulation_in_request,
+    get_chatlab_simulation_queryset_for_request,
 )
 from apps.simcore.models import Simulation
 from apps.simcore.tools import aget_tool, alist_tools
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 @login_required
 def index(request):
     simulations = (
-        get_simulation_queryset_for_request(request, request.user)
+        get_chatlab_simulation_queryset_for_request(request, request.user)
         if request.user.is_authenticated
         else Simulation.objects.none()
     )
@@ -68,7 +68,9 @@ def index(request):
     page_obj = paginator.get_page(page_number)
 
     template = (
-        "chatlab/partials/simulation_history_list.html" if request.htmx else "chatlab/index.html"
+        "chatlab/partials/simulation_history_list.html"
+        if getattr(request, "htmx", False)
+        else "chatlab/index.html"
     )
     return render(
         request,
@@ -99,9 +101,13 @@ async def create_simulation(request):
 
 @login_required
 @resolve_user
-@simulation_required("simulation_id", owner_required=True)
 async def run_simulation(request, simulation_id, included_tools="__ALL__"):
-    simulation = request.simulation
+    simulation = await sync_to_async(
+        lambda: get_object_or_404(
+            get_chatlab_simulation_queryset_for_request(request, request.user),
+            id=simulation_id,
+        )
+    )()
 
     tools = []
 
@@ -151,7 +157,7 @@ async def run_simulation(request, simulation_id, included_tools="__ALL__"):
 def get_metadata_checksum(request, simulation_id):
     """Return simulation metadata checksum."""
     simulation = get_object_or_404(
-        get_simulation_queryset_for_request(request, request.user),
+        get_chatlab_simulation_queryset_for_request(request, request.user),
         id=simulation_id,
     )
     return JsonResponse({"checksum": simulation.metadata_checksum})
@@ -160,7 +166,10 @@ def get_metadata_checksum(request, simulation_id):
 @require_GET
 @login_required
 def refresh_messages(request, simulation_id):
-    get_object_or_404(get_simulation_queryset_for_request(request, request.user), id=simulation_id)
+    get_object_or_404(
+        get_chatlab_simulation_queryset_for_request(request, request.user),
+        id=simulation_id,
+    )
     qs = Message.objects.filter(simulation_id=simulation_id)
 
     # Filter by conversation when specified (multi-conversation support)
@@ -176,7 +185,10 @@ def refresh_messages(request, simulation_id):
 @require_GET
 @login_required
 def load_older_messages(request, simulation_id):
-    get_object_or_404(get_simulation_queryset_for_request(request, request.user), id=simulation_id)
+    get_object_or_404(
+        get_chatlab_simulation_queryset_for_request(request, request.user),
+        id=simulation_id,
+    )
     before_id = request.GET.get("before")
     try:
         before_message = Message.objects.get(id=before_id, simulation_id=simulation_id)
@@ -224,7 +236,7 @@ def modifier_selector(request):
 @login_required
 def end_simulation(request, simulation_id):
     simulation = get_object_or_404(
-        get_simulation_queryset_for_request(request, request.user),
+        get_chatlab_simulation_queryset_for_request(request, request.user),
         id=simulation_id,
     )
     if not simulation.end_timestamp:
@@ -236,7 +248,10 @@ def end_simulation(request, simulation_id):
 @login_required
 def get_single_message(request, simulation_id, message_id):
     """Return HTML for a single message (for HTMX append after WebSocket notification)."""
-    get_object_or_404(get_simulation_queryset_for_request(request, request.user), id=simulation_id)
+    get_object_or_404(
+        get_chatlab_simulation_queryset_for_request(request, request.user),
+        id=simulation_id,
+    )
     try:
         message = (
             Message.objects.select_related("sender")
@@ -290,7 +305,7 @@ def watch_simulation(request, simulation_id):
         back_url=run_url,
         lab_name="ChatLab",
         can_go_to_simulation=request.user.is_authenticated
-        and can_access_simulation_in_request(request.user, simulation, request),
+        and can_access_chatlab_simulation_in_request(request.user, simulation, request),
         go_to_simulation_url=run_url,
     )
     return render(

--- a/SimWorks/apps/simcore/access.py
+++ b/SimWorks/apps/simcore/access.py
@@ -32,6 +32,11 @@ def get_simulation_queryset_for_request(request, user):
 
 
 def get_chatlab_simulation_queryset_for_request(request, user):
+    """Return request-scoped simulations that are ChatLab-backed.
+
+    This is the canonical ChatLab request-scoped queryset helper for both
+    web views and API endpoints.
+    """
     return get_simulation_queryset_for_request(request, user).filter(
         chatlab_session__isnull=False
     )

--- a/SimWorks/apps/simcore/access.py
+++ b/SimWorks/apps/simcore/access.py
@@ -37,9 +37,7 @@ def get_chatlab_simulation_queryset_for_request(request, user):
     This is the canonical ChatLab request-scoped queryset helper for both
     web views and API endpoints.
     """
-    return get_simulation_queryset_for_request(request, user).filter(
-        chatlab_session__isnull=False
-    )
+    return get_simulation_queryset_for_request(request, user).filter(chatlab_session__isnull=False)
 
 
 def get_simulation_queryset_for_scope(scope, user):
@@ -63,9 +61,9 @@ def can_access_simulation_in_request(user, simulation, request) -> bool:
 
 
 def can_access_chatlab_simulation_in_request(user, simulation, request) -> bool:
-    return get_chatlab_simulation_queryset_for_request(request, user).filter(
-        pk=simulation.pk
-    ).exists()
+    return (
+        get_chatlab_simulation_queryset_for_request(request, user).filter(pk=simulation.pk).exists()
+    )
 
 
 def can_access_simulation_in_scope(user, simulation, scope) -> bool:

--- a/SimWorks/apps/simcore/access.py
+++ b/SimWorks/apps/simcore/access.py
@@ -31,6 +31,12 @@ def get_simulation_queryset_for_request(request, user):
     return get_simulation_queryset_for_account(user, account)
 
 
+def get_chatlab_simulation_queryset_for_request(request, user):
+    return get_simulation_queryset_for_request(request, user).filter(
+        chatlab_session__isnull=False
+    )
+
+
 def get_simulation_queryset_for_scope(scope, user):
     from apps.simcore.models import Simulation
 
@@ -49,6 +55,12 @@ def can_access_simulation_in_request(user, simulation, request) -> bool:
     if simulation.account_id is None:
         return bool(getattr(account, "is_personal", False) and account.owner_user_id == user.id)
     return simulation.account_id == account.id
+
+
+def can_access_chatlab_simulation_in_request(user, simulation, request) -> bool:
+    return get_chatlab_simulation_queryset_for_request(request, user).filter(
+        pk=simulation.pk
+    ).exists()
 
 
 def can_access_simulation_in_scope(user, simulation, scope) -> bool:

--- a/tests/api/test_accounts_billing.py
+++ b/tests/api/test_accounts_billing.py
@@ -182,6 +182,10 @@ def test_account_scoped_simulation_listing_respects_org_roles(
     member_sim = Simulation.objects.create(
         user=member_user, account=org_account, sim_patient_full_name="Member"
     )
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.create(simulation=admin_sim)
+    ChatSession.objects.create(simulation=member_sim)
 
     admin_client = auth_client_factory(owner_user)
     member_client = auth_client_factory(member_user)

--- a/tests/api/test_conversations.py
+++ b/tests/api/test_conversations.py
@@ -13,6 +13,13 @@ import pytest
 from api.v1.auth import create_access_token
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     """Create a test user role."""
@@ -101,12 +108,13 @@ def simulation(test_user):
     """Create a test simulation."""
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="Jane Smith",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -11,6 +11,13 @@ from api.v1.auth import create_access_token
 from apps.common.outbox.event_types import MESSAGE_CREATED, PATIENT_RESULTS_UPDATED
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     from apps.accounts.models import UserRole
@@ -59,12 +66,13 @@ def auth_client(test_user):
 def simulation(test_user):
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="Events Patient",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture

--- a/tests/api/test_events_catchup.py
+++ b/tests/api/test_events_catchup.py
@@ -12,6 +12,13 @@ from api.v1.auth import create_access_token
 from apps.common.outbox.event_types import MESSAGE_CREATED, SIMULATION_STATUS_UPDATED
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     from apps.accounts.models import UserRole
@@ -59,12 +66,13 @@ def auth_client(test_user):
 def simulation(test_user):
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="John Doe",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture

--- a/tests/api/test_jwt_auth.py
+++ b/tests/api/test_jwt_auth.py
@@ -26,6 +26,13 @@ from api.v1.auth import (
 )
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def test_user(django_user_model):
     """Create a test user with a role."""
@@ -430,6 +437,7 @@ class TestDualAuth:
             user=test_user,
             sim_patient_full_name="Test Patient",
         )
+        _attach_chatlab_session(sim)
 
         response = client.get(f"/api/v1/simulations/{sim.pk}/messages/")
         assert response.status_code == 200
@@ -446,6 +454,7 @@ class TestDualAuth:
             user=test_user,
             sim_patient_full_name="Test Patient",
         )
+        _attach_chatlab_session(sim)
 
         response = client.get(
             f"/api/v1/simulations/{sim.pk}/messages/",
@@ -471,6 +480,7 @@ class TestDualAuth:
             user=test_user,
             sim_patient_full_name="Test Patient",
         )
+        _attach_chatlab_session(sim)
 
         # JWT is for other_user who doesn't own the simulation
         token = create_access_token(other_user)

--- a/tests/api/test_lab_orders.py
+++ b/tests/api/test_lab_orders.py
@@ -8,6 +8,13 @@ import pytest
 from api.v1.auth import create_access_token
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     from apps.accounts.models import UserRole
@@ -56,12 +63,13 @@ def auth_client(test_user):
 def simulation(test_user):
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="Lab Order Patient",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.mark.django_db

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -20,6 +20,13 @@ from api.v1.auth import create_access_token
 from tests.helpers.assertions import assert_payload_has_fields, assert_response_status
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     """Create a test user role."""
@@ -113,12 +120,13 @@ def simulation(test_user):
     """Create a test simulation."""
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="John Doe",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture

--- a/tests/api/test_simulations.py
+++ b/tests/api/test_simulations.py
@@ -179,9 +179,7 @@ class TestListSimulations:
         data = response.json()
         assert len(data["items"]) == 0  # No simulations for test_user
 
-    def test_list_simulations_excludes_trainerlab_backed_simulations(
-        self, auth_client, test_user
-    ):
+    def test_list_simulations_excludes_trainerlab_backed_simulations(self, auth_client, test_user):
         """ChatLab list only returns simulations with a ChatSession."""
         from apps.simcore.models import Simulation
         from apps.trainerlab.models import TrainerSession

--- a/tests/api/test_simulations.py
+++ b/tests/api/test_simulations.py
@@ -19,6 +19,13 @@ from api.v1.auth import create_access_token
 from tests.helpers.assertions import assert_payload_has_fields, assert_response_status
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     """Create a test user role."""
@@ -112,12 +119,13 @@ def simulation(test_user):
     """Create a test simulation."""
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="John Doe",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture
@@ -125,7 +133,8 @@ def chatlab_session(simulation):
     """Attach a ChatSession to the test simulation (makes it ChatLab-backed)."""
     from apps.chatlab.models import ChatSession
 
-    return ChatSession.objects.create(simulation=simulation)
+    session, _ = ChatSession.objects.get_or_create(simulation=simulation)
+    return session
 
 
 @pytest.mark.django_db
@@ -156,18 +165,42 @@ class TestListSimulations:
         from apps.simcore.models import Simulation
 
         # Create simulation for other user
-        Simulation.objects.create(
+        other_simulation = Simulation.objects.create(
             user=other_user,
             diagnosis="Other Diagnosis",
             chief_complaint="Other Complaint",
             sim_patient_full_name="Jane Doe",
         )
+        _attach_chatlab_session(other_simulation)
 
         response = auth_client.get("/api/v1/simulations/")
 
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 0  # No simulations for test_user
+
+    def test_list_simulations_excludes_trainerlab_backed_simulations(
+        self, auth_client, test_user
+    ):
+        """ChatLab list only returns simulations with a ChatSession."""
+        from apps.simcore.models import Simulation
+        from apps.trainerlab.models import TrainerSession
+
+        chatlab_simulation = Simulation.objects.create(
+            user=test_user,
+            sim_patient_full_name="ChatLab Patient",
+        )
+        _attach_chatlab_session(chatlab_simulation)
+        trainerlab_simulation = Simulation.objects.create(
+            user=test_user,
+            sim_patient_full_name="TrainerLab Patient",
+        )
+        TrainerSession.objects.create(simulation=trainerlab_simulation)
+
+        response = auth_client.get("/api/v1/simulations/")
+
+        assert response.status_code == 200
+        assert [item["id"] for item in response.json()["items"]] == [chatlab_simulation.id]
 
     def test_list_simulations_with_status_filter(self, auth_client, test_user):
         """Can filter by status."""
@@ -176,15 +209,17 @@ class TestListSimulations:
         from apps.simcore.models import Simulation
 
         # Create an in-progress and completed simulation
-        Simulation.objects.create(
+        active_simulation = Simulation.objects.create(
             user=test_user,
             sim_patient_full_name="Active Patient",
         )
-        Simulation.objects.create(
+        _attach_chatlab_session(active_simulation)
+        completed_simulation = Simulation.objects.create(
             user=test_user,
             sim_patient_full_name="Done Patient",
             end_timestamp=now(),
         )
+        _attach_chatlab_session(completed_simulation)
 
         # Filter for in_progress
         response = auth_client.get("/api/v1/simulations/?status=in_progress")
@@ -209,6 +244,7 @@ class TestListSimulations:
                 user=test_user,
                 sim_patient_full_name=f"Patient {i}",
             )
+            _attach_chatlab_session(sim)
             sims.append(sim)
 
         # Get first page with limit=2
@@ -241,7 +277,9 @@ class TestListSimulations:
         from apps.simcore.models import Simulation
 
         simulations = [
-            Simulation.objects.create(user=test_user, sim_patient_full_name=f"Patient {i}")
+            _attach_chatlab_session(
+                Simulation.objects.create(user=test_user, sim_patient_full_name=f"Patient {i}")
+            )
             for i in range(3)
         ]
         shared_timestamp = timezone.now()
@@ -270,16 +308,18 @@ class TestListSimulations:
     def test_list_simulations_supports_search_query(self, auth_client, test_user):
         from apps.simcore.models import Simulation
 
-        Simulation.objects.create(
+        pulmonary_simulation = Simulation.objects.create(
             user=test_user,
             diagnosis="Pulmonary Embolism",
             sim_patient_full_name="Patient A",
         )
-        Simulation.objects.create(
+        _attach_chatlab_session(pulmonary_simulation)
+        appendicitis_simulation = Simulation.objects.create(
             user=test_user,
             diagnosis="Appendicitis",
             sim_patient_full_name="Patient B",
         )
+        _attach_chatlab_session(appendicitis_simulation)
 
         response = auth_client.get("/api/v1/simulations/?q=Pulmonary")
         assert response.status_code == 200
@@ -295,6 +335,7 @@ class TestListSimulations:
             user=test_user,
             sim_patient_full_name="Patient M",
         )
+        _attach_chatlab_session(sim)
         conversation_type, _ = ConversationType.objects.get_or_create(
             slug="simulated_patient",
             defaults={
@@ -367,6 +408,21 @@ class TestGetSimulation:
 
         assert response.status_code == 404
 
+    def test_get_simulation_trainerlab_backed_returns_404(self, auth_client, test_user):
+        """ChatLab detail route does not expose TrainerLab-only simulations."""
+        from apps.simcore.models import Simulation
+        from apps.trainerlab.models import TrainerSession
+
+        trainerlab_simulation = Simulation.objects.create(
+            user=test_user,
+            sim_patient_full_name="TrainerLab Patient",
+        )
+        TrainerSession.objects.create(simulation=trainerlab_simulation)
+
+        response = auth_client.get(f"/api/v1/simulations/{trainerlab_simulation.pk}/")
+
+        assert response.status_code == 404
+
 
 @pytest.mark.django_db
 class TestCreateSimulation:
@@ -403,6 +459,9 @@ class TestCreateSimulation:
         assert data["chief_complaint"] == "New Complaint"
         assert data["status"] == "in_progress"
         assert data["user_id"] == test_user.pk
+        from apps.chatlab.models import ChatSession
+
+        assert ChatSession.objects.filter(simulation_id=data["id"]).exists()
 
     def test_create_simulation_with_time_limit(self, auth_client):
         """Creates simulation with time limit."""
@@ -661,6 +720,7 @@ class TestSimulationOutputFormat:
             sim_patient_full_name="Test Patient",
             time_limit=timedelta(hours=1),
         )
+        _attach_chatlab_session(sim)
 
         failure_artifacts.capture_request(method="GET", url=f"/api/v1/simulations/{sim.pk}/")
         response = auth_client.get(f"/api/v1/simulations/{sim.pk}/")
@@ -695,6 +755,7 @@ class TestSimulationOutputFormat:
             user=test_user,
             sim_patient_full_name="Patient",
         )
+        _attach_chatlab_session(sim)
         response = auth_client.get(f"/api/v1/simulations/{sim.pk}/")
         assert response.json()["status"] == "in_progress"
 
@@ -754,8 +815,10 @@ class TestSimulationOutputFormat:
         assert item["status"] == "failed"
         assert item["retryable"] is False
 
-    def test_trainerlab_failed_simulation_serializes_retryable_false(self, auth_client, test_user):
-        """TrainerLab-backed failed simulation always has retryable=False."""
+    def test_trainerlab_failed_simulation_is_hidden_from_chatlab_route(
+        self, auth_client, test_user
+    ):
+        """TrainerLab-backed failed simulations are not exposed by ChatLab detail."""
         from apps.simcore.models import Simulation
         from apps.trainerlab.models import TrainerSession
 
@@ -772,8 +835,7 @@ class TestSimulationOutputFormat:
         )
 
         response = auth_client.get(f"/api/v1/simulations/{sim.pk}/")
-        assert response.status_code == 200
-        assert response.json()["retryable"] is False
+        assert response.status_code == 404
 
     def test_legacy_initial_generation_code_retryable_for_chatlab_backed_simulation(
         self, auth_client, test_user
@@ -798,10 +860,10 @@ class TestSimulationOutputFormat:
         assert response.status_code == 200
         assert response.json()["retryable"] is True
 
-    def test_legacy_initial_generation_code_not_retryable_for_trainerlab_backed_simulation(
+    def test_legacy_initial_generation_code_hidden_for_trainerlab_backed_simulation(
         self, auth_client, test_user
     ):
-        """Legacy unprefixed initial_generation_* codes are NOT retryable for TrainerLab sims."""
+        """Legacy unprefixed initial_generation_* failures are hidden for TrainerLab sims."""
         from apps.simcore.models import Simulation
         from apps.trainerlab.models import TrainerSession
 
@@ -818,8 +880,7 @@ class TestSimulationOutputFormat:
         )
 
         response = auth_client.get(f"/api/v1/simulations/{sim.pk}/")
-        assert response.status_code == 200
-        assert response.json()["retryable"] is False
+        assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -884,8 +945,8 @@ class TestRetryInitialSimulation:
         assert data["terminal_reason_code"] == "chatlab_initial_generation_enqueue_failed"
         assert data["retryable"] is False
 
-    def test_retry_initial_rejects_trainerlab_simulation_with_400(self, auth_client, test_user):
-        """retry-initial/ returns 400 for a TrainerLab-backed simulation."""
+    def test_retry_initial_hides_trainerlab_simulation_with_404(self, auth_client, test_user):
+        """retry-initial/ does not expose TrainerLab-backed simulations."""
         from apps.simcore.models import Simulation
         from apps.trainerlab.models import TrainerSession
 
@@ -900,7 +961,7 @@ class TestRetryInitialSimulation:
         TrainerSession.objects.create(simulation=sim)
 
         response = auth_client.post(f"/api/v1/simulations/{sim.pk}/retry-initial/")
-        assert response.status_code == 400
+        assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_tools.py
+++ b/tests/api/test_tools.py
@@ -8,6 +8,13 @@ import pytest
 from api.v1.auth import create_access_token
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     from apps.accounts.models import UserRole
@@ -56,10 +63,11 @@ def auth_client(test_user):
 def simulation(test_user):
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=test_user,
         sim_patient_full_name="Tool Patient",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture

--- a/tests/chatlab/test_views.py
+++ b/tests/chatlab/test_views.py
@@ -7,6 +7,13 @@ from django.test import Client
 import pytest
 
 
+def _attach_chatlab_session(simulation):
+    from apps.chatlab.models import ChatSession
+
+    ChatSession.objects.get_or_create(simulation=simulation)
+    return simulation
+
+
 @pytest.fixture
 def user_role(db):
     """Create a test user role."""
@@ -44,12 +51,13 @@ def simulation(db, user):
     """Create a test simulation."""
     from apps.simcore.models import Simulation
 
-    return Simulation.objects.create(
+    simulation = Simulation.objects.create(
         user=user,
         diagnosis="Test Diagnosis",
         chief_complaint="Test Complaint",
         sim_patient_full_name="Test Patient",
     )
+    return _attach_chatlab_session(simulation)
 
 
 @pytest.fixture
@@ -136,6 +144,32 @@ def feedback_conversation_message(db, simulation, system_user, feedback_conversa
         is_from_ai=True,
         display_name="Stitch",
     )
+
+
+@pytest.mark.django_db
+class TestChatLabHome:
+    def test_index_excludes_trainerlab_backed_simulations(self, client: Client, user):
+        from apps.simcore.models import Simulation
+        from apps.trainerlab.models import TrainerSession
+
+        chatlab_simulation = Simulation.objects.create(
+            user=user,
+            sim_patient_full_name="ChatLab Patient",
+        )
+        _attach_chatlab_session(chatlab_simulation)
+        trainerlab_simulation = Simulation.objects.create(
+            user=user,
+            sim_patient_full_name="TrainerLab Patient",
+        )
+        TrainerSession.objects.create(simulation=trainerlab_simulation)
+
+        client.force_login(user)
+        response = client.get("/chatlab/")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert f'data-simulation-id="{chatlab_simulation.id}"' in content
+        assert f'data-simulation-id="{trainerlab_simulation.id}"' not in content
 
 
 @pytest.mark.django_db
@@ -261,6 +295,7 @@ class TestGetSingleMessage:
             chief_complaint="Other Complaint",
             sim_patient_full_name="Other Patient",
         )
+        _attach_chatlab_session(other_simulation)
 
         client.force_login(user)
 


### PR DESCRIPTION
## Summary
- Add ChatLab-scoped simulation helpers and use them across ChatLab API routes
- Scope ChatLab home and nested simulation endpoints to simulations with `ChatSession`
- Keep TrainerLab routes on the generic simulation helpers
- Update tests so TrainerLab-backed simulations are excluded from ChatLab list/detail paths

## Testing
- `uv run pytest -q tests/api/test_simulations.py tests/chatlab/test_views.py tests/api/test_messages.py tests/api/test_conversations.py tests/api/test_events.py tests/api/test_events_catchup.py tests/api/test_tools.py tests/api/test_lab_orders.py tests/api/test_jwt_auth.py tests/api/test_accounts_billing.py`
- `uv run pytest -q tests/api/test_trainerlab.py::TestTrainerLabGuardEndpoints`
- `uv run python SimWorks/manage.py check`
- `uv run ruff check SimWorks/api/v1/utils.py SimWorks/api/v1/endpoints/simulations.py SimWorks/api/v1/endpoints/conversations.py SimWorks/api/v1/endpoints/messages.py SimWorks/api/v1/endpoints/events.py SimWorks/api/v1/endpoints/tools.py SimWorks/api/v1/endpoints/_lab_order_submission.py SimWorks/apps/simcore/access.py SimWorks/apps/chatlab/views.py tests/api/test_simulations.py tests/chatlab/test_views.py tests/api/test_messages.py tests/api/test_conversations.py tests/api/test_events.py tests/api/test_events_catchup.py tests/api/test_tools.py tests/api/test_lab_orders.py tests/api/test_jwt_auth.py tests/api/test_accounts_billing.py`