### PR TITLE
Add simulation failure recording and auto-archival for TrainerLab

### DIFF
--- a/SimWorks/api/v1/endpoints/trainerlab.py
+++ b/SimWorks/api/v1/endpoints/trainerlab.py
@@ -791,7 +791,10 @@ def list_trainer_sessions(
 
     queryset = (
         TrainerSession.objects.select_related("simulation", "simulation__account")
-        .filter(simulation__in=simulation_queryset)
+        .filter(
+            simulation__in=simulation_queryset,
+            simulation__archived_at__isnull=True,
+        )
         .order_by("-id")
     )
 

--- a/SimWorks/api/v1/endpoints/trainerlab.py
+++ b/SimWorks/api/v1/endpoints/trainerlab.py
@@ -784,19 +784,22 @@ def list_trainer_sessions(
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = Query(default=None),
     status: str | None = Query(default=None),
+    include_archived: bool = Query(default=False),
 ) -> PaginatedResponse[TrainerRunOut]:
     user = request.auth
     _require_lab_access(request)
     simulation_queryset = get_simulation_queryset_for_request(request, user)
 
+    # Only staff users may opt into seeing archived sessions.
+    show_archived = include_archived and getattr(user, "is_staff", False)
+
     queryset = (
         TrainerSession.objects.select_related("simulation", "simulation__account")
-        .filter(
-            simulation__in=simulation_queryset,
-            simulation__archived_at__isnull=True,
-        )
+        .filter(simulation__in=simulation_queryset)
         .order_by("-id")
     )
+    if not show_archived:
+        queryset = queryset.filter(simulation__archived_at__isnull=True)
 
     if status:
         queryset = queryset.filter(status=status)

--- a/SimWorks/api/v1/schemas/trainerlab.py
+++ b/SimWorks/api/v1/schemas/trainerlab.py
@@ -55,6 +55,9 @@ class TrainerRunOut(BaseModel):
     terminal_reason_code: str | None = None
     terminal_reason_text: str | None = None
     retryable: bool | None = None
+    archived_at: datetime | None = None
+    archived_reason: str | None = None
+    archived_by_id: int | None = None
 
 
 class TrainerCommandAck(BaseModel):
@@ -934,6 +937,9 @@ def trainer_run_to_out(session: TrainerSession) -> TrainerRunOut:
         terminal_reason_code=terminal_reason_code,
         terminal_reason_text=terminal_reason_text,
         retryable=retryable,
+        archived_at=simulation.archived_at,
+        archived_reason=simulation.archived_reason or None,
+        archived_by_id=simulation.archived_by_id,
     )
 
 

--- a/SimWorks/apps/chatlab/views.py
+++ b/SimWorks/apps/chatlab/views.py
@@ -25,7 +25,7 @@ from apps.common.retries import (
 )
 from apps.common.watch import build_watch_page_context, build_watch_service_calls_context
 from apps.simcore.access import (
-    can_access_chatlab_simulation_in_request,
+    can_access_simulation_in_request,
     get_chatlab_simulation_queryset_for_request,
 )
 from apps.simcore.models import Simulation
@@ -305,7 +305,7 @@ def watch_simulation(request, simulation_id):
         back_url=run_url,
         lab_name="ChatLab",
         can_go_to_simulation=request.user.is_authenticated
-        and can_access_chatlab_simulation_in_request(request.user, simulation, request),
+        and can_access_simulation_in_request(request.user, simulation, request),
         go_to_simulation_url=run_url,
     )
     return render(

--- a/SimWorks/apps/guards/signals.py
+++ b/SimWorks/apps/guards/signals.py
@@ -54,12 +54,14 @@ def on_service_call_succeeded(sender, **kwargs):
     lab_type = _detect_lab_type(simulation)
     product_code = _resolve_product_code(simulation, lab_type)
 
+    from apps.simcore.services import is_simulation_billable
     from .services import record_usage
 
+    billable = is_simulation_billable(simulation)
     record_usage(
         simulation_id=simulation_id,
-        user_id=getattr(simulation.user, "pk", None),
-        account_id=getattr(simulation.account, "pk", None),
+        user_id=getattr(simulation.user, "pk", None) if billable else None,
+        account_id=getattr(simulation.account, "pk", None) if billable else None,
         lab_type=lab_type,
         product_code=product_code,
         input_tokens=getattr(call, "input_tokens", 0) or 0,

--- a/SimWorks/apps/guards/signals.py
+++ b/SimWorks/apps/guards/signals.py
@@ -55,9 +55,10 @@ def on_service_call_succeeded(sender, **kwargs):
     product_code = _resolve_product_code(simulation, lab_type)
 
     from apps.simcore.services import is_simulation_billable
+
     from .services import record_usage
 
-    billable = is_simulation_billable(simulation)
+    billable = is_simulation_billable(simulation, lab_type=lab_type)
     record_usage(
         simulation_id=simulation_id,
         user_id=getattr(simulation.user, "pk", None) if billable else None,

--- a/SimWorks/apps/simcore/migrations/0009_simulation_archival.py
+++ b/SimWorks/apps/simcore/migrations/0009_simulation_archival.py
@@ -1,0 +1,51 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("simcore", "0008_backfill_simulation_accounts"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="simulation",
+            name="archived_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="simulation",
+            name="archived_reason",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("system_failed", "System: Failed"),
+                    ("user_archived", "User Archived"),
+                    ("staff_archived", "Staff Archived"),
+                ],
+                db_index=True,
+                default="",
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name="simulation",
+            name="archived_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="archived_simulations",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="simulation",
+            index=models.Index(
+                fields=["status", "archived_at"], name="idx_sim_status_archived"
+            ),
+        ),
+    ]

--- a/SimWorks/apps/simcore/models.py
+++ b/SimWorks/apps/simcore/models.py
@@ -241,6 +241,11 @@ class Simulation(models.Model):
         FAILED = "failed", "Failed"
         CANCELED = "canceled", "Canceled"
 
+    class ArchiveReason(models.TextChoices):
+        SYSTEM_FAILED  = "system_failed",  "System: Failed"
+        USER_ARCHIVED  = "user_archived",  "User Archived"
+        STAFF_ARCHIVED = "staff_archived", "Staff Archived"
+
     start_timestamp = models.DateTimeField(auto_now_add=True)
     end_timestamp = models.DateTimeField(blank=True, null=True)
     status = models.CharField(
@@ -252,6 +257,24 @@ class Simulation(models.Model):
     terminal_reason_code = models.CharField(max_length=100, blank=True, default="")
     terminal_reason_text = models.TextField(blank=True, default="")
     terminal_at = models.DateTimeField(blank=True, null=True)
+
+    # Soft user-facing archival — archived_at is null means active in default hub queries.
+    archived_at = models.DateTimeField(blank=True, null=True, db_index=True)
+    archived_reason = models.CharField(
+        max_length=32,
+        blank=True,
+        default="",
+        choices=ArchiveReason.choices,
+        db_index=True,
+    )
+    archived_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="archived_simulations",
+    )
+
     initial_retry_count = models.PositiveSmallIntegerField(default=0)
     feedback_retry_count = models.PositiveSmallIntegerField(default=0)
 
@@ -301,6 +324,7 @@ class Simulation(models.Model):
         indexes = [
             models.Index(fields=["account", "start_timestamp"], name="idx_sim_account_started"),
             models.Index(fields=["account", "status"], name="idx_sim_account_status"),
+            models.Index(fields=["status", "archived_at"], name="idx_sim_status_archived"),
         ]
 
     def history(self, _format=None) -> list:
@@ -366,6 +390,35 @@ class Simulation(models.Model):
     @property
     def is_canceled(self) -> bool:
         return self.status == self.SimulationStatus.CANCELED
+
+    @property
+    def is_archived(self) -> bool:
+        return self.archived_at is not None
+
+    def archive(
+        self,
+        *,
+        reason: str,
+        archived_by=None,
+        timestamp=None,
+        save: bool = True,
+    ) -> None:
+        """Soft user-facing archival. Does not delete data or alter terminal status fields."""
+        if self.archived_at is not None:
+            return  # idempotent
+        self.archived_at = timestamp or now()
+        self.archived_reason = reason
+        self.archived_by = archived_by
+        if save:
+            self.save(update_fields=["archived_at", "archived_reason", "archived_by"])
+
+    def unarchive(self, *, save: bool = True) -> None:
+        """Clear archival fields, restoring the simulation to the default hub view."""
+        self.archived_at = None
+        self.archived_reason = ""
+        self.archived_by = None
+        if save:
+            self.save(update_fields=["archived_at", "archived_reason", "archived_by"])
 
     @property
     def length(self) -> timedelta | None:

--- a/SimWorks/apps/simcore/models.py
+++ b/SimWorks/apps/simcore/models.py
@@ -242,8 +242,8 @@ class Simulation(models.Model):
         CANCELED = "canceled", "Canceled"
 
     class ArchiveReason(models.TextChoices):
-        SYSTEM_FAILED  = "system_failed",  "System: Failed"
-        USER_ARCHIVED  = "user_archived",  "User Archived"
+        SYSTEM_FAILED = "system_failed", "System: Failed"
+        USER_ARCHIVED = "user_archived", "User Archived"
         STAFF_ARCHIVED = "staff_archived", "Staff Archived"
 
     start_timestamp = models.DateTimeField(auto_now_add=True)

--- a/SimWorks/apps/simcore/services.py
+++ b/SimWorks/apps/simcore/services.py
@@ -3,10 +3,23 @@ from __future__ import annotations
 from .models import Simulation
 
 
-def is_simulation_billable(simulation: "Simulation") -> bool:
-    """Returns False for failed simulations (non-billable for quota purposes).
+def is_simulation_billable(simulation: Simulation, *, lab_type: str = "") -> bool:
+    """Returns False only for failed TrainerLab simulations (non-billable for quota).
 
-    Raw session-level UsageRecord rows are always preserved regardless.
-    Only customer-facing user/account usage aggregation is affected.
+    The billing exclusion is intentionally scoped to TrainerLab.  Failed
+    simulations from other labs remain billable unless that rule is explicitly
+    extended here.
+
+    Raw session-level UsageRecord rows are always preserved regardless of this
+    return value — only customer-facing user/account quota aggregation is affected.
+
+    Args:
+        simulation: The Simulation instance to check.
+        lab_type:   The lab type string (e.g. "trainerlab", "chatlab").
+                    Callers that have already resolved the lab type should pass it
+                    to avoid redundant DB lookups.  Defaults to "" which conservatively
+                    treats the simulation as billable unless it is clearly TrainerLab.
     """
-    return simulation.status != Simulation.SimulationStatus.FAILED
+    if simulation.status != Simulation.SimulationStatus.FAILED:
+        return True
+    return lab_type != "trainerlab"

--- a/SimWorks/apps/simcore/services.py
+++ b/SimWorks/apps/simcore/services.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .models import Simulation
+
+
+def is_simulation_billable(simulation: "Simulation") -> bool:
+    """Returns False for failed simulations (non-billable for quota purposes).
+
+    Raw session-level UsageRecord rows are always preserved regardless.
+    Only customer-facing user/account usage aggregation is affected.
+    """
+    return simulation.status != Simulation.SimulationStatus.FAILED

--- a/SimWorks/apps/simcore/tests.py
+++ b/SimWorks/apps/simcore/tests.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -18,8 +17,7 @@ def _make_user(email="test@example.com"):
 
 
 def _make_simulation(user=None, status=Simulation.SimulationStatus.IN_PROGRESS):
-    sim = Simulation.objects.create(user=user, status=status)
-    return sim
+    return Simulation.objects.create(user=user, status=status)
 
 
 class SimulationArchiveMethodTests(TestCase):
@@ -50,7 +48,6 @@ class SimulationArchiveMethodTests(TestCase):
         first_ts = now() - timedelta(seconds=10)
         self.sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED, timestamp=first_ts)
         self.sim.refresh_from_db()
-        # Second call with different timestamp should be a no-op
         second_ts = now()
         self.sim.archive(reason=Simulation.ArchiveReason.USER_ARCHIVED, timestamp=second_ts)
         self.sim.refresh_from_db()
@@ -67,9 +64,7 @@ class SimulationArchiveMethodTests(TestCase):
 
     def test_archive_without_save_does_not_persist(self):
         self.sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED, save=False)
-        # In-memory change applied
         self.assertTrue(self.sim.is_archived)
-        # But not persisted
         fresh = Simulation.objects.get(pk=self.sim.pk)
         self.assertFalse(fresh.is_archived)
 
@@ -82,22 +77,33 @@ class SimulationArchiveMethodTests(TestCase):
 
 
 class IsSimulationBillableTests(TestCase):
+    """is_simulation_billable() is scoped to TrainerLab failed simulations only."""
+
     def test_in_progress_simulation_is_billable(self):
         sim = _make_simulation(status=Simulation.SimulationStatus.IN_PROGRESS)
-        self.assertTrue(is_simulation_billable(sim))
+        self.assertTrue(is_simulation_billable(sim, lab_type="trainerlab"))
 
     def test_completed_simulation_is_billable(self):
         sim = _make_simulation(status=Simulation.SimulationStatus.COMPLETED)
-        self.assertTrue(is_simulation_billable(sim))
+        self.assertTrue(is_simulation_billable(sim, lab_type="trainerlab"))
 
     def test_timed_out_simulation_is_billable(self):
         sim = _make_simulation(status=Simulation.SimulationStatus.TIMED_OUT)
-        self.assertTrue(is_simulation_billable(sim))
+        self.assertTrue(is_simulation_billable(sim, lab_type="trainerlab"))
 
     def test_canceled_simulation_is_billable(self):
         sim = _make_simulation(status=Simulation.SimulationStatus.CANCELED)
-        self.assertTrue(is_simulation_billable(sim))
+        self.assertTrue(is_simulation_billable(sim, lab_type="trainerlab"))
 
-    def test_failed_simulation_is_not_billable(self):
+    def test_failed_trainerlab_simulation_is_not_billable(self):
         sim = _make_simulation(status=Simulation.SimulationStatus.FAILED)
-        self.assertFalse(is_simulation_billable(sim))
+        self.assertFalse(is_simulation_billable(sim, lab_type="trainerlab"))
+
+    def test_failed_chatlab_simulation_is_billable(self):
+        sim = _make_simulation(status=Simulation.SimulationStatus.FAILED)
+        self.assertTrue(is_simulation_billable(sim, lab_type="chatlab"))
+
+    def test_failed_simulation_without_lab_type_is_billable(self):
+        # Conservative default: unknown lab type → billable
+        sim = _make_simulation(status=Simulation.SimulationStatus.FAILED)
+        self.assertTrue(is_simulation_billable(sim))

--- a/SimWorks/apps/simcore/tests.py
+++ b/SimWorks/apps/simcore/tests.py
@@ -1,1 +1,103 @@
-# Create your tests here.
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+
+from apps.accounts.models import UserRole
+from apps.simcore.models import Simulation
+from apps.simcore.services import is_simulation_billable
+
+User = get_user_model()
+
+
+def _make_user(email="test@example.com"):
+    role, _ = UserRole.objects.get_or_create(title="Tester")
+    return User.objects.create_user(email=email, password="pw", role=role)
+
+
+def _make_simulation(user=None, status=Simulation.SimulationStatus.IN_PROGRESS):
+    sim = Simulation.objects.create(user=user, status=status)
+    return sim
+
+
+class SimulationArchiveMethodTests(TestCase):
+    def setUp(self):
+        self.user = _make_user()
+        self.sim = _make_simulation(user=self.user)
+
+    def test_is_archived_false_when_archived_at_is_null(self):
+        self.assertFalse(self.sim.is_archived)
+
+    def test_is_archived_true_after_archive(self):
+        self.sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED)
+        self.assertTrue(self.sim.is_archived)
+
+    def test_archive_sets_all_fields(self):
+        ts = now()
+        self.sim.archive(
+            reason=Simulation.ArchiveReason.USER_ARCHIVED,
+            archived_by=self.user,
+            timestamp=ts,
+        )
+        self.sim.refresh_from_db()
+        self.assertEqual(self.sim.archived_at, ts)
+        self.assertEqual(self.sim.archived_reason, Simulation.ArchiveReason.USER_ARCHIVED)
+        self.assertEqual(self.sim.archived_by, self.user)
+
+    def test_archive_is_idempotent(self):
+        first_ts = now() - timedelta(seconds=10)
+        self.sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED, timestamp=first_ts)
+        self.sim.refresh_from_db()
+        # Second call with different timestamp should be a no-op
+        second_ts = now()
+        self.sim.archive(reason=Simulation.ArchiveReason.USER_ARCHIVED, timestamp=second_ts)
+        self.sim.refresh_from_db()
+        self.assertEqual(self.sim.archived_at, first_ts)
+        self.assertEqual(self.sim.archived_reason, Simulation.ArchiveReason.SYSTEM_FAILED)
+
+    def test_unarchive_clears_fields(self):
+        self.sim.archive(reason=Simulation.ArchiveReason.STAFF_ARCHIVED, archived_by=self.user)
+        self.sim.unarchive()
+        self.sim.refresh_from_db()
+        self.assertIsNone(self.sim.archived_at)
+        self.assertEqual(self.sim.archived_reason, "")
+        self.assertIsNone(self.sim.archived_by)
+
+    def test_archive_without_save_does_not_persist(self):
+        self.sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED, save=False)
+        # In-memory change applied
+        self.assertTrue(self.sim.is_archived)
+        # But not persisted
+        fresh = Simulation.objects.get(pk=self.sim.pk)
+        self.assertFalse(fresh.is_archived)
+
+    def test_unarchive_without_save_does_not_persist(self):
+        self.sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED)
+        self.sim.unarchive(save=False)
+        self.assertIsNone(self.sim.archived_at)
+        fresh = Simulation.objects.get(pk=self.sim.pk)
+        self.assertIsNotNone(fresh.archived_at)
+
+
+class IsSimulationBillableTests(TestCase):
+    def test_in_progress_simulation_is_billable(self):
+        sim = _make_simulation(status=Simulation.SimulationStatus.IN_PROGRESS)
+        self.assertTrue(is_simulation_billable(sim))
+
+    def test_completed_simulation_is_billable(self):
+        sim = _make_simulation(status=Simulation.SimulationStatus.COMPLETED)
+        self.assertTrue(is_simulation_billable(sim))
+
+    def test_timed_out_simulation_is_billable(self):
+        sim = _make_simulation(status=Simulation.SimulationStatus.TIMED_OUT)
+        self.assertTrue(is_simulation_billable(sim))
+
+    def test_canceled_simulation_is_billable(self):
+        sim = _make_simulation(status=Simulation.SimulationStatus.CANCELED)
+        self.assertTrue(is_simulation_billable(sim))
+
+    def test_failed_simulation_is_not_billable(self):
+        sim = _make_simulation(status=Simulation.SimulationStatus.FAILED)
+        self.assertFalse(is_simulation_billable(sim))

--- a/SimWorks/apps/trainerlab/admin.py
+++ b/SimWorks/apps/trainerlab/admin.py
@@ -22,6 +22,7 @@ from .models import (
     ScenarioBrief,
     ScenarioInstruction,
     ScenarioInstructionPermission,
+    SimulationFailureRecord,
     SimulationNote,
     TrainerCommand,
     TrainerRunSummary,
@@ -261,3 +262,40 @@ class BloodPressureAdmin(admin.ModelAdmin):
 admin.site.register(TrainerRunSummary)
 admin.site.register(ScenarioInstruction)
 admin.site.register(ScenarioInstructionPermission)
+
+
+@admin.register(SimulationFailureRecord)
+class SimulationFailureRecordAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "simulation",
+        "environment",
+        "lab_slug",
+        "terminal_reason_code",
+        "retryable",
+        "created_at",
+    )
+    list_filter = ("environment", "lab_slug", "retryable")
+    search_fields = (
+        "simulation__id",
+        "trainer_session__id",
+        "correlation_id",
+        "terminal_reason_code",
+        "exception_class",
+    )
+    readonly_fields = (
+        "simulation",
+        "trainer_session",
+        "created_at",
+        "updated_at",
+        "environment",
+        "lab_slug",
+        "terminal_reason_code",
+        "terminal_reason_text",
+        "exception_class",
+        "exception_message",
+        "traceback_text",
+        "correlation_id",
+        "service_call_id",
+    )
+    ordering = ("-created_at",)

--- a/SimWorks/apps/trainerlab/failure_service.py
+++ b/SimWorks/apps/trainerlab/failure_service.py
@@ -2,7 +2,12 @@
 
 This module is the single place that:
   1. Creates/updates a durable SimulationFailureRecord when a simulation fails.
-  2. Sends an operational email alert to the errors inbox.
+  2. Sends an operational email alert to the errors inbox (first occurrence only).
+
+``finalize_trainerlab_failure()`` is the canonical entry point for ALL terminal
+TrainerLab failure paths.  It is idempotent: the failure record is upserted on
+every call, but the alert email is sent only when the record is first created so
+repeated invocations do not produce duplicate noise.
 
 Both operations are best-effort: exceptions are caught and logged so that
 a failure in this module never prevents the upstream failure path from completing.
@@ -10,7 +15,12 @@ a failure in this module never prevents the upstream failure path from completin
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from config.logging import get_logger
+
+if TYPE_CHECKING:
+    from .models import SimulationFailureRecord
 
 logger = get_logger(__name__)
 
@@ -24,29 +34,22 @@ def _get_environment() -> str:
     return str(getattr(settings, "EMAIL_ENVIRONMENT_NAME", "unknown")).strip() or "unknown"
 
 
-def record_simulation_failure(
+def _build_failure_defaults(
     *,
     simulation,
-    trainer_session=None,
-    reason_code: str = "",
-    reason_text: str = "",
-    exception_class: str = "",
-    exception_message: str = "",
-    traceback_text: str = "",
-    correlation_id: str = "",
-    service_call_id: str = "",
-    retryable: bool = True,
-    metadata: dict | None = None,
-) -> "SimulationFailureRecord":
-    """Idempotent upsert of a SimulationFailureRecord keyed by simulation.
-
-    The OneToOneField on simulation guarantees at most one record per simulation.
-    Repeated calls update the existing record rather than creating duplicates.
-    """
-    from .models import SimulationFailureRecord
-
+    trainer_session,
+    reason_code: str,
+    reason_text: str,
+    exception_class: str,
+    exception_message: str,
+    traceback_text: str,
+    correlation_id: str,
+    service_call_id: str,
+    retryable: bool,
+    metadata: dict | None,
+) -> dict:
     environment = _get_environment()
-    defaults = {
+    return {
         "environment": environment,
         "lab_slug": LAB_SLUG,
         "trainer_session": trainer_session,
@@ -64,6 +67,100 @@ def record_simulation_failure(
         "retryable": retryable,
         "metadata_json": metadata or {},
     }
+
+
+def finalize_trainerlab_failure(
+    *,
+    simulation,
+    trainer_session=None,
+    reason_code: str = "",
+    reason_text: str = "",
+    exception_class: str = "",
+    exception_message: str = "",
+    traceback_text: str = "",
+    correlation_id: str = "",
+    service_call_id: str = "",
+    retryable: bool = True,
+    metadata: dict | None = None,
+) -> None:
+    """Canonical entry point for all TrainerLab terminal failure handling.
+
+    Must be called from every code path that transitions a TrainerLab
+    session/simulation to a terminal FAILED state.
+
+    Idempotent: the SimulationFailureRecord is upserted on every call (OneToOne
+    guarantees at most one row per simulation); the alert email is sent only when
+    the record is first created to avoid duplicate noise.
+
+    This function is non-fatal: all exceptions are caught and logged so that
+    callers are never disrupted.
+    """
+    try:
+        from .models import SimulationFailureRecord
+
+        defaults = _build_failure_defaults(
+            simulation=simulation,
+            trainer_session=trainer_session,
+            reason_code=reason_code,
+            reason_text=reason_text,
+            exception_class=exception_class,
+            exception_message=exception_message,
+            traceback_text=traceback_text,
+            correlation_id=correlation_id,
+            service_call_id=service_call_id,
+            retryable=retryable,
+            metadata=metadata,
+        )
+        record, created = SimulationFailureRecord.objects.update_or_create(
+            simulation=simulation,
+            defaults=defaults,
+        )
+        if created:
+            send_failure_alert_email(record)
+    except Exception:
+        logger.exception(
+            "finalize_trainerlab_failure.error",
+            simulation_id=getattr(simulation, "pk", None),
+        )
+
+
+def record_simulation_failure(
+    *,
+    simulation,
+    trainer_session=None,
+    reason_code: str = "",
+    reason_text: str = "",
+    exception_class: str = "",
+    exception_message: str = "",
+    traceback_text: str = "",
+    correlation_id: str = "",
+    service_call_id: str = "",
+    retryable: bool = True,
+    metadata: dict | None = None,
+) -> SimulationFailureRecord:
+    """Idempotent upsert of a SimulationFailureRecord keyed by simulation.
+
+    The OneToOneField on simulation guarantees at most one record per simulation.
+    Repeated calls update the existing record rather than creating duplicates.
+
+    Prefer ``finalize_trainerlab_failure()`` for production failure paths — it
+    combines record upsert + alert email with correct idempotency semantics.
+    """
+    from .models import SimulationFailureRecord
+
+    defaults = _build_failure_defaults(
+        simulation=simulation,
+        trainer_session=trainer_session,
+        reason_code=reason_code,
+        reason_text=reason_text,
+        exception_class=exception_class,
+        exception_message=exception_message,
+        traceback_text=traceback_text,
+        correlation_id=correlation_id,
+        service_call_id=service_call_id,
+        retryable=retryable,
+        metadata=metadata,
+    )
     record, _ = SimulationFailureRecord.objects.update_or_create(
         simulation=simulation,
         defaults=defaults,
@@ -75,12 +172,11 @@ def send_failure_alert_email(failure_record) -> None:
     """Send an operational summary email to errors@jackfruitco.com.
 
     Production failures send immediately.  Staging failures include a [STAGING]
-    prefix (applied automatically by the email service's staging support).
-    This function is non-fatal: exceptions are logged and swallowed.
+    prefix.  This function is non-fatal: exceptions are logged and swallowed.
     """
     try:
-        from apps.common.emailing.service import send_transactional_email
         from apps.common.emailing.environment import get_email_environment_label
+        from apps.common.emailing.service import send_transactional_email
 
         environment = failure_record.environment
         environment_label = get_email_environment_label(environment_hint=environment)
@@ -122,6 +218,11 @@ def send_failure_alert_email(failure_record) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Backward-compat alias — prefer finalize_trainerlab_failure() for new code.
+# ---------------------------------------------------------------------------
+
+
 def handle_simulation_failure(
     *,
     simulation,
@@ -136,24 +237,22 @@ def handle_simulation_failure(
     retryable: bool = True,
     metadata: dict | None = None,
 ) -> None:
-    """Convenience wrapper: record failure and send alert in one call."""
-    try:
-        record = record_simulation_failure(
-            simulation=simulation,
-            trainer_session=trainer_session,
-            reason_code=reason_code,
-            reason_text=reason_text,
-            exception_class=exception_class,
-            exception_message=exception_message,
-            traceback_text=traceback_text,
-            correlation_id=correlation_id,
-            service_call_id=service_call_id,
-            retryable=retryable,
-            metadata=metadata,
-        )
-        send_failure_alert_email(record)
-    except Exception:
-        logger.exception(
-            "failure_service.handle_simulation_failure_error",
-            simulation_id=getattr(simulation, "pk", None),
-        )
+    """Deprecated alias for ``finalize_trainerlab_failure()``.
+
+    Kept for callers that have not yet been migrated.  Unlike the old
+    implementation this now delegates to ``finalize_trainerlab_failure()``
+    so email idempotency is also enforced here.
+    """
+    finalize_trainerlab_failure(
+        simulation=simulation,
+        trainer_session=trainer_session,
+        reason_code=reason_code,
+        reason_text=reason_text,
+        exception_class=exception_class,
+        exception_message=exception_message,
+        traceback_text=traceback_text,
+        correlation_id=correlation_id,
+        service_call_id=service_call_id,
+        retryable=retryable,
+        metadata=metadata,
+    )

--- a/SimWorks/apps/trainerlab/failure_service.py
+++ b/SimWorks/apps/trainerlab/failure_service.py
@@ -1,0 +1,159 @@
+"""Centralised handling for TrainerLab simulation failure records and alerting.
+
+This module is the single place that:
+  1. Creates/updates a durable SimulationFailureRecord when a simulation fails.
+  2. Sends an operational email alert to the errors inbox.
+
+Both operations are best-effort: exceptions are caught and logged so that
+a failure in this module never prevents the upstream failure path from completing.
+"""
+
+from __future__ import annotations
+
+from config.logging import get_logger
+
+logger = get_logger(__name__)
+
+FAILURE_ALERT_RECIPIENT = "errors@jackfruitco.com"
+LAB_SLUG = "trainerlab"
+
+
+def _get_environment() -> str:
+    from django.conf import settings
+
+    return str(getattr(settings, "EMAIL_ENVIRONMENT_NAME", "unknown")).strip() or "unknown"
+
+
+def record_simulation_failure(
+    *,
+    simulation,
+    trainer_session=None,
+    reason_code: str = "",
+    reason_text: str = "",
+    exception_class: str = "",
+    exception_message: str = "",
+    traceback_text: str = "",
+    correlation_id: str = "",
+    service_call_id: str = "",
+    retryable: bool = True,
+    metadata: dict | None = None,
+) -> "SimulationFailureRecord":
+    """Idempotent upsert of a SimulationFailureRecord keyed by simulation.
+
+    The OneToOneField on simulation guarantees at most one record per simulation.
+    Repeated calls update the existing record rather than creating duplicates.
+    """
+    from .models import SimulationFailureRecord
+
+    environment = _get_environment()
+    defaults = {
+        "environment": environment,
+        "lab_slug": LAB_SLUG,
+        "trainer_session": trainer_session,
+        "user_id": simulation.user_id,
+        "account_id": simulation.account_id,
+        "simulation_status": simulation.status,
+        "session_status": getattr(trainer_session, "status", "") if trainer_session else "",
+        "terminal_reason_code": reason_code or simulation.terminal_reason_code or "",
+        "terminal_reason_text": reason_text or simulation.terminal_reason_text or "",
+        "exception_class": exception_class,
+        "exception_message": exception_message,
+        "traceback_text": traceback_text,
+        "correlation_id": correlation_id,
+        "service_call_id": service_call_id,
+        "retryable": retryable,
+        "metadata_json": metadata or {},
+    }
+    record, _ = SimulationFailureRecord.objects.update_or_create(
+        simulation=simulation,
+        defaults=defaults,
+    )
+    return record
+
+
+def send_failure_alert_email(failure_record) -> None:
+    """Send an operational summary email to errors@jackfruitco.com.
+
+    Production failures send immediately.  Staging failures include a [STAGING]
+    prefix (applied automatically by the email service's staging support).
+    This function is non-fatal: exceptions are logged and swallowed.
+    """
+    try:
+        from apps.common.emailing.service import send_transactional_email
+        from apps.common.emailing.environment import get_email_environment_label
+
+        environment = failure_record.environment
+        environment_label = get_email_environment_label(environment_hint=environment)
+        is_staging = environment_label == "staging"
+        staging_prefix = "[STAGING] " if is_staging else ""
+
+        subject = (
+            f"{staging_prefix}TrainerLab Simulation Failure — "
+            f"sim#{failure_record.simulation_id} [{environment}]"
+        )
+        body_lines = [
+            f"Environment:       {environment}",
+            f"Lab:               {failure_record.lab_slug}",
+            f"Simulation ID:     {failure_record.simulation_id}",
+            f"Trainer Session:   {failure_record.trainer_session_id or 'N/A'}",
+            f"User ID:           {failure_record.user_id or 'N/A'}",
+            f"Account ID:        {failure_record.account_id or 'N/A'}",
+            f"Terminal Code:     {failure_record.terminal_reason_code or 'N/A'}",
+            f"Terminal Text:     {failure_record.terminal_reason_text or 'N/A'}",
+            f"Exception:         {failure_record.exception_class or 'N/A'}"
+            + (f": {failure_record.exception_message}" if failure_record.exception_message else ""),
+            f"Correlation ID:    {failure_record.correlation_id or 'N/A'}",
+            f"Service Call ID:   {failure_record.service_call_id or 'N/A'}",
+            f"Retryable:         {failure_record.retryable}",
+            "",
+            "Archival policy: this simulation will be auto-archived after a 5-minute grace period.",
+        ]
+        text_body = "\n".join(body_lines)
+        send_transactional_email(
+            to=[FAILURE_ALERT_RECIPIENT],
+            subject=subject,
+            text_body=text_body,
+            environment_hint=environment,
+        )
+    except Exception:
+        logger.exception(
+            "failure_service.email_alert_failed",
+            simulation_id=failure_record.simulation_id,
+        )
+
+
+def handle_simulation_failure(
+    *,
+    simulation,
+    trainer_session=None,
+    reason_code: str = "",
+    reason_text: str = "",
+    exception_class: str = "",
+    exception_message: str = "",
+    traceback_text: str = "",
+    correlation_id: str = "",
+    service_call_id: str = "",
+    retryable: bool = True,
+    metadata: dict | None = None,
+) -> None:
+    """Convenience wrapper: record failure and send alert in one call."""
+    try:
+        record = record_simulation_failure(
+            simulation=simulation,
+            trainer_session=trainer_session,
+            reason_code=reason_code,
+            reason_text=reason_text,
+            exception_class=exception_class,
+            exception_message=exception_message,
+            traceback_text=traceback_text,
+            correlation_id=correlation_id,
+            service_call_id=service_call_id,
+            retryable=retryable,
+            metadata=metadata,
+        )
+        send_failure_alert_email(record)
+    except Exception:
+        logger.exception(
+            "failure_service.handle_simulation_failure_error",
+            simulation_id=getattr(simulation, "pk", None),
+        )

--- a/SimWorks/apps/trainerlab/migrations/0022_simulationfailurerecord.py
+++ b/SimWorks/apps/trainerlab/migrations/0022_simulationfailurerecord.py
@@ -1,0 +1,74 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("simcore", "0009_simulation_archival"),
+        ("trainerlab", "0021_traineridempotencyclaim"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SimulationFailureRecord",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("environment", models.CharField(blank=True, db_index=True, default="", max_length=32)),
+                ("lab_slug", models.CharField(blank=True, db_index=True, default="", max_length=64)),
+                (
+                    "simulation",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="failure_record",
+                        to="simcore.simulation",
+                    ),
+                ),
+                (
+                    "trainer_session",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="failure_records",
+                        to="trainerlab.trainersession",
+                    ),
+                ),
+                ("user_id", models.IntegerField(blank=True, null=True)),
+                ("account_id", models.IntegerField(blank=True, null=True)),
+                ("simulation_status", models.CharField(blank=True, default="", max_length=24)),
+                ("session_status", models.CharField(blank=True, default="", max_length=16)),
+                ("terminal_reason_code", models.CharField(blank=True, default="", max_length=100)),
+                ("terminal_reason_text", models.TextField(blank=True, default="")),
+                ("exception_class", models.CharField(blank=True, default="", max_length=255)),
+                ("exception_message", models.TextField(blank=True, default="")),
+                ("traceback_text", models.TextField(blank=True, default="")),
+                (
+                    "correlation_id",
+                    models.CharField(blank=True, db_index=True, default="", max_length=100),
+                ),
+                ("service_call_id", models.CharField(blank=True, default="", max_length=100)),
+                ("retryable", models.BooleanField(default=True)),
+                ("metadata_json", models.JSONField(blank=True, default=dict)),
+                ("resolved_at", models.DateTimeField(blank=True, null=True)),
+            ],
+            options={
+                "indexes": [
+                    models.Index(
+                        fields=["environment", "lab_slug", "created_at"],
+                        name="idx_failure_env_lab",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/SimWorks/apps/trainerlab/models.py
+++ b/SimWorks/apps/trainerlab/models.py
@@ -1875,3 +1875,68 @@ class PulseAssessment(BaseDomainEvent):
             f"PulseAssessment {self.timestamp:%H:%M:%S} "
             f"{self.location}: {'present' if self.present else 'absent'} ({self.description})"
         )
+
+
+# ---------------------------------------------------------------------------
+# Failure records
+# ---------------------------------------------------------------------------
+
+
+class SimulationFailureRecord(models.Model):
+    """Structured durable record of a terminal simulation failure.
+
+    One row per simulation (OneToOneField enforces idempotency).
+    Captures environment, linkage, terminal reason, exception, and trace info
+    for staff-visible operational review.
+    """
+
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    environment = models.CharField(max_length=32, blank=True, default="", db_index=True)
+    lab_slug = models.CharField(max_length=64, blank=True, default="", db_index=True)
+
+    simulation = models.OneToOneField(
+        "simcore.Simulation",
+        on_delete=models.CASCADE,
+        related_name="failure_record",
+    )
+    trainer_session = models.ForeignKey(
+        "trainerlab.TrainerSession",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="failure_records",
+    )
+
+    user_id = models.IntegerField(null=True, blank=True)
+    account_id = models.IntegerField(null=True, blank=True)
+
+    simulation_status = models.CharField(max_length=24, blank=True, default="")
+    session_status = models.CharField(max_length=16, blank=True, default="")
+
+    terminal_reason_code = models.CharField(max_length=100, blank=True, default="")
+    terminal_reason_text = models.TextField(blank=True, default="")
+
+    exception_class = models.CharField(max_length=255, blank=True, default="")
+    exception_message = models.TextField(blank=True, default="")
+    traceback_text = models.TextField(blank=True, default="")
+
+    correlation_id = models.CharField(max_length=100, blank=True, default="", db_index=True)
+    service_call_id = models.CharField(max_length=100, blank=True, default="")
+
+    retryable = models.BooleanField(default=True)
+    metadata_json = models.JSONField(default=dict, blank=True)
+
+    resolved_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        indexes = [
+            models.Index(
+                fields=["environment", "lab_slug", "created_at"],
+                name="idx_failure_env_lab",
+            ),
+        ]
+
+    def __str__(self):
+        return f"FailureRecord(sim={self.simulation_id}, code={self.terminal_reason_code})"

--- a/SimWorks/apps/trainerlab/services.py
+++ b/SimWorks/apps/trainerlab/services.py
@@ -871,6 +871,24 @@ def fail_initial_scenario_generation(
             "reason_text": reason_text,
         },
     )
+
+    try:
+        from .failure_service import handle_simulation_failure
+
+        handle_simulation_failure(
+            simulation=session.simulation,
+            trainer_session=session,
+            reason_code=normalized_reason,
+            reason_text=reason_text,
+            retryable=retryable,
+            correlation_id=correlation_id or "",
+        )
+    except Exception:
+        logger.exception(
+            "trainerlab.fail_initial.failure_service_error",
+            simulation_id=simulation_id,
+        )
+
     return session
 
 

--- a/SimWorks/apps/trainerlab/services.py
+++ b/SimWorks/apps/trainerlab/services.py
@@ -872,22 +872,16 @@ def fail_initial_scenario_generation(
         },
     )
 
-    try:
-        from .failure_service import handle_simulation_failure
+    from .failure_service import finalize_trainerlab_failure
 
-        handle_simulation_failure(
-            simulation=session.simulation,
-            trainer_session=session,
-            reason_code=normalized_reason,
-            reason_text=reason_text,
-            retryable=retryable,
-            correlation_id=correlation_id or "",
-        )
-    except Exception:
-        logger.exception(
-            "trainerlab.fail_initial.failure_service_error",
-            simulation_id=simulation_id,
-        )
+    finalize_trainerlab_failure(
+        simulation=session.simulation,
+        trainer_session=session,
+        reason_code=normalized_reason,
+        reason_text=reason_text,
+        retryable=retryable,
+        correlation_id=correlation_id or "",
+    )
 
     return session
 

--- a/SimWorks/apps/trainerlab/tasks.py
+++ b/SimWorks/apps/trainerlab/tasks.py
@@ -4,6 +4,7 @@ from celery import shared_task
 from django.tasks import task
 from django.utils import timezone
 
+from apps.common.utils import get_system_user
 from config.logging import get_logger
 
 from .models import SessionStatus, TrainerSession
@@ -104,7 +105,6 @@ def archive_failed_trainerlab_simulations() -> None:
     """
     from datetime import timedelta
 
-    from apps.common.utils import get_system_user
     from apps.simcore.models import Simulation
 
     cutoff = timezone.now() - timedelta(seconds=FAILED_SIMULATION_ARCHIVE_AFTER_SECONDS)

--- a/SimWorks/apps/trainerlab/tasks.py
+++ b/SimWorks/apps/trainerlab/tasks.py
@@ -11,6 +11,9 @@ from .services import append_pending_runtime_reason, process_runtime_turn_queue
 
 logger = get_logger(__name__)
 
+# Grace period before a failed TrainerLab simulation is auto-archived.
+FAILED_SIMULATION_ARCHIVE_AFTER_SECONDS = 300
+
 
 @task
 def trainerlab_process_runtime_turn(*, session_id: int) -> str | None:
@@ -86,4 +89,54 @@ def trainerlab_runtime_tick(self, session_id: int, tick_nonce: int) -> None:
             "trainerlab.tick.reschedule_failed",
             session_id=session.id,
             tick_nonce=tick_nonce,
+        )
+
+
+@shared_task(ignore_result=True)
+def archive_failed_trainerlab_simulations() -> None:
+    """Archive failed TrainerLab simulations that have passed the grace period.
+
+    Runs periodically via Celery beat.  Only targets simulations that:
+      - have status=FAILED
+      - reached terminal_at more than FAILED_SIMULATION_ARCHIVE_AFTER_SECONDS ago
+      - are not yet archived
+      - have an associated TrainerSession (TrainerLab-owned only)
+    """
+    from datetime import timedelta
+
+    from apps.common.utils import get_system_user
+    from apps.simcore.models import Simulation
+
+    cutoff = timezone.now() - timedelta(seconds=FAILED_SIMULATION_ARCHIVE_AFTER_SECONDS)
+    qs = Simulation.objects.filter(
+        status=Simulation.SimulationStatus.FAILED,
+        terminal_at__lte=cutoff,
+        archived_at__isnull=True,
+        trainerlab_session__isnull=False,
+    )
+
+    system_user = None
+    try:
+        system_user = get_system_user()
+    except Exception:
+        logger.exception("archive_failed_trainerlab_simulations.system_user_error")
+
+    archived_count = 0
+    for simulation in qs.iterator():
+        try:
+            simulation.archive(
+                reason=Simulation.ArchiveReason.SYSTEM_FAILED,
+                archived_by=system_user,
+            )
+            archived_count += 1
+        except Exception:
+            logger.exception(
+                "archive_failed_trainerlab_simulations.archive_error",
+                simulation_id=simulation.pk,
+            )
+
+    if archived_count:
+        logger.info(
+            "archive_failed_trainerlab_simulations.done",
+            archived_count=archived_count,
         )

--- a/SimWorks/apps/trainerlab/tests.py
+++ b/SimWorks/apps/trainerlab/tests.py
@@ -14,8 +14,17 @@ from apps.common.outbox import event_types as outbox_events
 from apps.guards.enums import UsageScopeType
 from apps.guards.models import UsageRecord
 from apps.simcore.models import Simulation
-from apps.trainerlab.failure_service import record_simulation_failure, send_failure_alert_email
-from apps.trainerlab.models import RuntimeEvent, SessionStatus, SimulationFailureRecord
+from apps.trainerlab.failure_service import (
+    finalize_trainerlab_failure,
+    record_simulation_failure,
+    send_failure_alert_email,
+)
+from apps.trainerlab.models import (
+    RuntimeEvent,
+    SessionStatus,
+    SimulationFailureRecord,
+    TrainerSession,
+)
 from apps.trainerlab.services import (
     complete_initial_scenario_generation,
     create_session,
@@ -267,6 +276,7 @@ class TrainerSessionLifecycleEventTests(TestCase):
 # Helpers shared by archival / failure-record tests
 # ---------------------------------------------------------------------------
 
+
 def _make_role():
     role, _ = UserRole.objects.get_or_create(title="Tester")
     return role
@@ -426,21 +436,19 @@ class SimulationFailureRecordTests(TestCase):
             user=self.user,
             status=Simulation.SimulationStatus.IN_PROGRESS,
         )
-        from apps.trainerlab.models import TrainerSession
-
-        session = TrainerSession.objects.create(
+        TrainerSession.objects.create(
             simulation=sim2,
             status=SessionStatus.SEEDING,
         )
 
         with patch("apps.common.emailing.service.send_transactional_email"):
             fail_initial_scenario_generation(
-                    simulation_id=sim2.pk,
-                    reason_code="provider_error",
-                    reason_text="Connection refused.",
-                    retryable=False,
-                    correlation_id="corr-fail-rec",
-                )
+                simulation_id=sim2.pk,
+                reason_code="provider_error",
+                reason_text="Connection refused.",
+                retryable=False,
+                correlation_id="corr-fail-rec",
+            )
 
         self.assertTrue(SimulationFailureRecord.objects.filter(simulation=sim2).exists())
         record = SimulationFailureRecord.objects.get(simulation=sim2)
@@ -511,7 +519,7 @@ class FailureAlertEmailTests(TestCase):
 
 
 class BillingExclusionSignalTests(TestCase):
-    """on_service_call_succeeded skips user/account usage rows for FAILED sims."""
+    """on_service_call_succeeded skips user/account usage rows for failed TrainerLab sims only."""
 
     def setUp(self):
         self.user = _make_user(email="billing@example.com")
@@ -528,22 +536,39 @@ class BillingExclusionSignalTests(TestCase):
         call.related_object_id = None
         on_service_call_succeeded(sender=None, call=call)
 
-    def test_failed_sim_creates_session_usage_but_not_user_or_account(self):
+    def test_failed_trainerlab_sim_creates_session_usage_but_not_user_or_account(self):
+        """A failed TrainerLab simulation (has TrainerSession) is non-billable for quota."""
         sim = Simulation.objects.create(
             user=self.user,
             status=Simulation.SimulationStatus.FAILED,
         )
+        TrainerSession.objects.create(simulation=sim, status=SessionStatus.FAILED)
 
         self._dispatch_service_call_succeeded(sim)
 
         session_records = UsageRecord.objects.filter(
             scope_type=UsageScopeType.SESSION, simulation=sim
         )
-        user_records = UsageRecord.objects.filter(
-            scope_type=UsageScopeType.USER, user=self.user
-        )
+        user_records = UsageRecord.objects.filter(scope_type=UsageScopeType.USER, user=self.user)
         self.assertEqual(session_records.count(), 1)
         self.assertEqual(user_records.count(), 0)
+
+    def test_failed_non_trainerlab_sim_creates_all_three_usage_scopes(self):
+        """A failed simulation without a TrainerSession is treated as ChatLab — still billable."""
+        sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+        )
+        # No TrainerSession → _detect_lab_type returns "chatlab" → billable
+
+        self._dispatch_service_call_succeeded(sim)
+
+        session_records = UsageRecord.objects.filter(
+            scope_type=UsageScopeType.SESSION, simulation=sim
+        )
+        user_records = UsageRecord.objects.filter(scope_type=UsageScopeType.USER, user=self.user)
+        self.assertEqual(session_records.count(), 1)
+        self.assertEqual(user_records.count(), 1)
 
     def test_completed_sim_creates_all_three_usage_scopes(self):
         sim = Simulation.objects.create(
@@ -556,11 +581,197 @@ class BillingExclusionSignalTests(TestCase):
         session_records = UsageRecord.objects.filter(
             scope_type=UsageScopeType.SESSION, simulation=sim
         )
-        user_records = UsageRecord.objects.filter(
-            scope_type=UsageScopeType.USER, user=self.user
-        )
+        user_records = UsageRecord.objects.filter(scope_type=UsageScopeType.USER, user=self.user)
         self.assertEqual(session_records.count(), 1)
         self.assertEqual(user_records.count(), 1)
+
+
+class FinalizeTrainerlabFailureTests(TestCase):
+    """finalize_trainerlab_failure() is the canonical entry point with email idempotency."""
+
+    def setUp(self):
+        self.user = _make_user(email="finalize@example.com")
+        self.sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+        )
+        self.session = TrainerSession.objects.create(
+            simulation=self.sim,
+            status=SessionStatus.FAILED,
+        )
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_creates_failure_record_on_first_call(self, _mock_send):
+        finalize_trainerlab_failure(
+            simulation=self.sim,
+            trainer_session=self.session,
+            reason_code="init_error",
+            retryable=False,
+        )
+        self.assertTrue(SimulationFailureRecord.objects.filter(simulation=self.sim).exists())
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_sends_alert_email_on_first_call(self, mock_send):
+        finalize_trainerlab_failure(
+            simulation=self.sim,
+            trainer_session=self.session,
+            reason_code="init_error",
+            retryable=False,
+        )
+        mock_send.assert_called_once()
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_does_not_send_email_on_subsequent_calls(self, mock_send):
+        """Repeated calls update the record but do not re-send the alert."""
+        finalize_trainerlab_failure(
+            simulation=self.sim,
+            trainer_session=self.session,
+            reason_code="init_error",
+            retryable=False,
+        )
+        finalize_trainerlab_failure(
+            simulation=self.sim,
+            trainer_session=self.session,
+            reason_code="updated_code",
+            retryable=True,
+        )
+        # Email sent exactly once (first creation only)
+        self.assertEqual(mock_send.call_count, 1)
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_updates_record_on_subsequent_calls(self, _mock_send):
+        finalize_trainerlab_failure(
+            simulation=self.sim,
+            trainer_session=self.session,
+            reason_code="first_code",
+            retryable=True,
+        )
+        finalize_trainerlab_failure(
+            simulation=self.sim,
+            trainer_session=self.session,
+            reason_code="second_code",
+            retryable=False,
+        )
+        record = SimulationFailureRecord.objects.get(simulation=self.sim)
+        self.assertEqual(record.terminal_reason_code, "second_code")
+        self.assertFalse(record.retryable)
+
+    def test_is_non_fatal_when_db_raises(self):
+        """Exceptions inside finalize_trainerlab_failure must not propagate."""
+        with patch(
+            "apps.trainerlab.models.SimulationFailureRecord.objects.update_or_create",
+            side_effect=Exception("DB exploded"),
+        ):
+            # Should not raise
+            finalize_trainerlab_failure(
+                simulation=self.sim,
+                trainer_session=self.session,
+                reason_code="error",
+            )
+
+
+class AutoArchivalSystemUserTests(TestCase):
+    """archive_failed_trainerlab_simulations() sets archived_by to the system user."""
+
+    def setUp(self):
+        self.user = _make_user(email="sysuser@example.com")
+
+    def _make_archivable(self):
+        sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+            terminal_at=now() - timedelta(minutes=10),
+        )
+        TrainerSession.objects.create(simulation=sim, status=SessionStatus.FAILED)
+        return sim
+
+    def test_archives_with_system_user_as_archived_by(self):
+        sim = self._make_archivable()
+
+        system_user = _make_user(email="system@medsim.local")
+        with patch("apps.trainerlab.tasks.get_system_user", return_value=system_user):
+            archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertTrue(sim.is_archived)
+        self.assertEqual(sim.archived_by, system_user)
+        self.assertEqual(sim.archived_reason, Simulation.ArchiveReason.SYSTEM_FAILED)
+
+    def test_archives_even_if_system_user_resolution_fails(self):
+        sim = self._make_archivable()
+
+        with patch(
+            "apps.trainerlab.tasks.get_system_user",
+            side_effect=Exception("user not found"),
+        ):
+            # Should not raise; task falls back to archived_by=None
+            archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertTrue(sim.is_archived)
+        self.assertIsNone(sim.archived_by)
+
+    def test_archives_sets_reason_system_failed(self):
+        sim = self._make_archivable()
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertEqual(sim.archived_reason, Simulation.ArchiveReason.SYSTEM_FAILED)
+
+
+class IncludeArchivedSessionQueryTests(TestCase):
+    """list_trainer_sessions include_archived flag is gated to staff users only."""
+
+    def setUp(self):
+        self.user = _make_user(email="listtest@example.com")
+
+        self.active_sim = Simulation.objects.create(user=self.user)
+        self.active_session = TrainerSession.objects.create(
+            simulation=self.active_sim,
+            status=SessionStatus.SEEDED,
+        )
+
+        archived_sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+            terminal_at=now() - timedelta(minutes=10),
+        )
+        archived_sim.archive(reason=Simulation.ArchiveReason.SYSTEM_FAILED)
+        self.archived_session = TrainerSession.objects.create(
+            simulation=archived_sim,
+            status=SessionStatus.FAILED,
+        )
+
+    def _filtered_qs(self, *, is_staff: bool, include_archived: bool):
+        sim_qs = Simulation.objects.filter(user=self.user)
+        show_archived = include_archived and is_staff
+        qs = TrainerSession.objects.filter(simulation__in=sim_qs)
+        if not show_archived:
+            qs = qs.filter(simulation__archived_at__isnull=True)
+        return qs
+
+    def test_default_excludes_archived_for_normal_user(self):
+        qs = self._filtered_qs(is_staff=False, include_archived=False)
+        self.assertIn(self.active_session, qs)
+        self.assertNotIn(self.archived_session, qs)
+
+    def test_normal_user_include_archived_true_still_excluded(self):
+        # Non-staff: include_archived=True is silently ignored
+        qs = self._filtered_qs(is_staff=False, include_archived=True)
+        self.assertIn(self.active_session, qs)
+        self.assertNotIn(self.archived_session, qs)
+
+    def test_staff_with_include_archived_true_sees_archived(self):
+        qs = self._filtered_qs(is_staff=True, include_archived=True)
+        self.assertIn(self.active_session, qs)
+        self.assertIn(self.archived_session, qs)
+
+    def test_staff_without_include_archived_flag_still_excludes(self):
+        # Staff must opt in explicitly; default remains exclusive
+        qs = self._filtered_qs(is_staff=True, include_archived=False)
+        self.assertIn(self.active_session, qs)
+        self.assertNotIn(self.archived_session, qs)
 
 
 class AdminRegistrationSmokeTest(TestCase):

--- a/SimWorks/apps/trainerlab/tests.py
+++ b/SimWorks/apps/trainerlab/tests.py
@@ -1,20 +1,30 @@
+from datetime import timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
+from django.utils.timezone import now
 from pydantic import ValidationError
 
 from api.v1.schemas.trainerlab import VitalCreateIn
 from apps.accounts.models import UserRole
 from apps.common.models import OutboxEvent
 from apps.common.outbox import event_types as outbox_events
-from apps.trainerlab.models import RuntimeEvent, SessionStatus
+from apps.guards.enums import UsageScopeType
+from apps.guards.models import UsageRecord
+from apps.simcore.models import Simulation
+from apps.trainerlab.failure_service import record_simulation_failure, send_failure_alert_email
+from apps.trainerlab.models import RuntimeEvent, SessionStatus, SimulationFailureRecord
 from apps.trainerlab.services import (
     complete_initial_scenario_generation,
     create_session,
     fail_initial_scenario_generation,
     retry_initial_scenario_generation,
+)
+from apps.trainerlab.tasks import (
+    FAILED_SIMULATION_ARCHIVE_AFTER_SECONDS,
+    archive_failed_trainerlab_simulations,
 )
 
 User = get_user_model()
@@ -251,3 +261,312 @@ class TrainerSessionLifecycleEventTests(TestCase):
             event_type=outbox_events.SIMULATION_STATUS_UPDATED,
         ).count()
         self.assertEqual(runtime_status_count, 3)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by archival / failure-record tests
+# ---------------------------------------------------------------------------
+
+def _make_role():
+    role, _ = UserRole.objects.get_or_create(title="Tester")
+    return role
+
+
+def _make_user(email="archtest@example.com"):
+    role = _make_role()
+    return User.objects.create_user(email=email, password="pw", role=role)
+
+
+def _make_failed_sim(user=None, minutes_ago=6):
+    """Return a FAILED Simulation whose terminal_at is *minutes_ago* minutes in the past."""
+    terminal = now() - timedelta(minutes=minutes_ago)
+    sim = Simulation.objects.create(
+        user=user,
+        status=Simulation.SimulationStatus.FAILED,
+        terminal_at=terminal,
+    )
+    return sim
+
+
+def _make_trainer_session(sim, user=None):
+    """Attach a minimal TrainerSession row to *sim*."""
+    from apps.trainerlab.models import TrainerSession
+
+    return TrainerSession.objects.create(
+        simulation=sim,
+        status=SessionStatus.FAILED,
+    )
+
+
+class AutoArchivalTaskTests(TestCase):
+    """archive_failed_trainerlab_simulations() respects grace period and scope."""
+
+    def setUp(self):
+        self.user = _make_user()
+
+    def test_archives_failed_sim_past_grace_period(self):
+        sim = _make_failed_sim(user=self.user, minutes_ago=6)
+        _make_trainer_session(sim, self.user)
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertTrue(sim.is_archived)
+        self.assertEqual(sim.archived_reason, Simulation.ArchiveReason.SYSTEM_FAILED)
+
+    def test_does_not_archive_sim_within_grace_period(self):
+        sim = _make_failed_sim(user=self.user, minutes_ago=2)
+        _make_trainer_session(sim, self.user)
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertFalse(sim.is_archived)
+
+    def test_does_not_archive_completed_sim(self):
+        terminal = now() - timedelta(minutes=10)
+        sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.COMPLETED,
+            terminal_at=terminal,
+        )
+        _make_trainer_session(sim, self.user)
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertFalse(sim.is_archived)
+
+    def test_does_not_archive_timed_out_sim(self):
+        terminal = now() - timedelta(minutes=10)
+        sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.TIMED_OUT,
+            terminal_at=terminal,
+        )
+        _make_trainer_session(sim, self.user)
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertFalse(sim.is_archived)
+
+    def test_does_not_archive_failed_sim_without_trainer_session(self):
+        sim = _make_failed_sim(user=self.user, minutes_ago=10)
+        # No TrainerSession attached
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertFalse(sim.is_archived)
+
+    def test_idempotent_does_not_overwrite_already_archived(self):
+        sim = _make_failed_sim(user=self.user, minutes_ago=10)
+        _make_trainer_session(sim, self.user)
+        first_ts = now() - timedelta(hours=1)
+        sim.archive(
+            reason=Simulation.ArchiveReason.USER_ARCHIVED,
+            archived_by=self.user,
+            timestamp=first_ts,
+        )
+
+        archive_failed_trainerlab_simulations()
+
+        sim.refresh_from_db()
+        self.assertEqual(sim.archived_reason, Simulation.ArchiveReason.USER_ARCHIVED)
+        self.assertEqual(sim.archived_at, first_ts)
+
+    def test_grace_period_constant_is_300_seconds(self):
+        self.assertEqual(FAILED_SIMULATION_ARCHIVE_AFTER_SECONDS, 300)
+
+
+class SimulationFailureRecordTests(TestCase):
+    """SimulationFailureRecord creation, idempotency, and fields."""
+
+    def setUp(self):
+        self.user = _make_user(email="failrec@example.com")
+        self.sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+        )
+
+    def test_record_simulation_failure_creates_record(self):
+        record = record_simulation_failure(
+            simulation=self.sim,
+            reason_code="provider_timeout",
+            reason_text="AI timed out.",
+            correlation_id="corr-123",
+            retryable=True,
+        )
+        self.assertIsNotNone(record.pk)
+        self.assertEqual(record.simulation, self.sim)
+        self.assertEqual(record.terminal_reason_code, "provider_timeout")
+        self.assertEqual(record.correlation_id, "corr-123")
+        self.assertTrue(record.retryable)
+
+    def test_record_simulation_failure_is_idempotent(self):
+        record_simulation_failure(
+            simulation=self.sim,
+            reason_code="first_code",
+            retryable=True,
+        )
+        record_simulation_failure(
+            simulation=self.sim,
+            reason_code="second_code",
+            retryable=False,
+        )
+        self.assertEqual(SimulationFailureRecord.objects.filter(simulation=self.sim).count(), 1)
+        updated = SimulationFailureRecord.objects.get(simulation=self.sim)
+        self.assertEqual(updated.terminal_reason_code, "second_code")
+        self.assertFalse(updated.retryable)
+
+    def test_fail_initial_scenario_generation_creates_failure_record(self):
+        """fail_initial_scenario_generation() hooks into failure_service."""
+        sim2 = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.IN_PROGRESS,
+        )
+        from apps.trainerlab.models import TrainerSession
+
+        session = TrainerSession.objects.create(
+            simulation=sim2,
+            status=SessionStatus.SEEDING,
+        )
+
+        with patch("apps.common.emailing.service.send_transactional_email"):
+            fail_initial_scenario_generation(
+                    simulation_id=sim2.pk,
+                    reason_code="provider_error",
+                    reason_text="Connection refused.",
+                    retryable=False,
+                    correlation_id="corr-fail-rec",
+                )
+
+        self.assertTrue(SimulationFailureRecord.objects.filter(simulation=sim2).exists())
+        record = SimulationFailureRecord.objects.get(simulation=sim2)
+        self.assertIn("provider_error", record.terminal_reason_code)
+        self.assertEqual(record.correlation_id, "corr-fail-rec")
+        self.assertFalse(record.retryable)
+
+
+class FailureAlertEmailTests(TestCase):
+    """send_failure_alert_email() subject and recipient logic."""
+
+    def setUp(self):
+        self.user = _make_user(email="emailtest@example.com")
+        self.sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+        )
+
+    def _make_record(self, environment="staging"):
+        return SimulationFailureRecord.objects.create(
+            simulation=self.sim,
+            environment=environment,
+            lab_slug="trainerlab",
+            terminal_reason_code="test_code",
+            retryable=True,
+        )
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_staging_subject_has_staging_prefix(self, mock_send):
+        record = self._make_record(environment="staging")
+        send_failure_alert_email(record)
+        mock_send.assert_called_once()
+        subject = mock_send.call_args[1]["subject"]
+        self.assertIn("[STAGING]", subject)
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_production_subject_has_no_staging_prefix(self, mock_send):
+        record = self._make_record(environment="production")
+        send_failure_alert_email(record)
+        mock_send.assert_called_once()
+        subject = mock_send.call_args[1]["subject"]
+        self.assertNotIn("[STAGING]", subject)
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_recipient_is_errors_inbox(self, mock_send):
+        record = self._make_record()
+        send_failure_alert_email(record)
+        mock_send.assert_called_once()
+        to = mock_send.call_args[1]["to"]
+        self.assertIn("errors@jackfruitco.com", to)
+
+    @patch("apps.common.emailing.service.send_transactional_email")
+    def test_body_contains_simulation_id_and_reason_code(self, mock_send):
+        record = self._make_record()
+        send_failure_alert_email(record)
+        text_body = mock_send.call_args[1]["text_body"]
+        self.assertIn(str(self.sim.pk), text_body)
+        self.assertIn("test_code", text_body)
+
+    @patch(
+        "apps.common.emailing.service.send_transactional_email",
+        side_effect=Exception("SMTP down"),
+    )
+    def test_email_failure_is_non_fatal(self, _mock_send):
+        record = self._make_record()
+        # Should not raise
+        send_failure_alert_email(record)
+
+
+class BillingExclusionSignalTests(TestCase):
+    """on_service_call_succeeded skips user/account usage rows for FAILED sims."""
+
+    def setUp(self):
+        self.user = _make_user(email="billing@example.com")
+
+    def _dispatch_service_call_succeeded(self, simulation):
+        from apps.guards.signals import on_service_call_succeeded
+
+        call = MagicMock()
+        call.total_tokens = 100
+        call.input_tokens = 40
+        call.output_tokens = 60
+        call.reasoning_tokens = 0
+        call.context = {"simulation_id": simulation.pk}
+        call.related_object_id = None
+        on_service_call_succeeded(sender=None, call=call)
+
+    def test_failed_sim_creates_session_usage_but_not_user_or_account(self):
+        sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.FAILED,
+        )
+
+        self._dispatch_service_call_succeeded(sim)
+
+        session_records = UsageRecord.objects.filter(
+            scope_type=UsageScopeType.SESSION, simulation=sim
+        )
+        user_records = UsageRecord.objects.filter(
+            scope_type=UsageScopeType.USER, user=self.user
+        )
+        self.assertEqual(session_records.count(), 1)
+        self.assertEqual(user_records.count(), 0)
+
+    def test_completed_sim_creates_all_three_usage_scopes(self):
+        sim = Simulation.objects.create(
+            user=self.user,
+            status=Simulation.SimulationStatus.COMPLETED,
+        )
+
+        self._dispatch_service_call_succeeded(sim)
+
+        session_records = UsageRecord.objects.filter(
+            scope_type=UsageScopeType.SESSION, simulation=sim
+        )
+        user_records = UsageRecord.objects.filter(
+            scope_type=UsageScopeType.USER, user=self.user
+        )
+        self.assertEqual(session_records.count(), 1)
+        self.assertEqual(user_records.count(), 1)
+
+
+class AdminRegistrationSmokeTest(TestCase):
+    """SimulationFailureRecordAdmin is registered in Django admin."""
+
+    def test_simulation_failure_record_admin_registered(self):
+        from django.contrib import admin
+
+        self.assertIn(SimulationFailureRecord, admin.site._registry)

--- a/SimWorks/config/celery.py
+++ b/SimWorks/config/celery.py
@@ -36,6 +36,11 @@ app.conf.beat_schedule = {
         "task": "apps.guards.tasks.check_stale_sessions",
         "schedule": 15.0,  # seconds
     },
+    # Archive failed TrainerLab simulations after the 5-minute grace period.
+    "archive-failed-trainerlab-sims-every-60-seconds": {
+        "task": "apps.trainerlab.tasks.archive_failed_trainerlab_simulations",
+        "schedule": 60.0,  # seconds
+    },
 }
 
 # @signals.worker_process_init.connect

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2317,6 +2317,16 @@
               "title": "Status"
             },
             "required": false
+          },
+          {
+            "in": "query",
+            "name": "include_archived",
+            "schema": {
+              "default": false,
+              "title": "Include Archived",
+              "type": "boolean"
+            },
+            "required": false
           }
         ],
         "responses": {
@@ -7061,6 +7071,40 @@
               }
             ],
             "title": "Retryable"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          },
+          "archived_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived Reason"
+          },
+          "archived_by_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived By Id"
           }
         },
         "required": [


### PR DESCRIPTION
## Summary
This PR introduces comprehensive failure tracking and automatic archival for failed TrainerLab simulations. It adds a durable `SimulationFailureRecord` model to capture structured failure information, implements operational alerting via email, and introduces a periodic task to auto-archive failed simulations after a grace period. Additionally, it excludes failed simulations from customer billing.

## Key Changes

### Failure Recording & Alerting
- **New `SimulationFailureRecord` model** (`apps/trainerlab/models.py`): Stores structured failure metadata including reason codes, exception details, correlation IDs, and environment context. Uses OneToOneField on Simulation to enforce idempotency.
- **New `failure_service.py` module** (`apps/trainerlab/failure_service.py`): Centralizes failure handling with three functions:
  - `record_simulation_failure()`: Idempotent upsert of failure records
  - `send_failure_alert_email()`: Non-fatal operational alerting to errors@jackfruitco.com with environment-aware subject lines
  - `handle_simulation_failure()`: Convenience wrapper combining both operations
- **Integration with existing failure path** (`apps/trainerlab/services.py`): `fail_initial_scenario_generation()` now calls `handle_simulation_failure()` to record and alert on failures

### Simulation Archival
- **New archival fields on Simulation model** (`apps/simcore/models.py`):
  - `archived_at`: Timestamp of archival (null = active)
  - `archived_reason`: Choice field (SYSTEM_FAILED, USER_ARCHIVED, STAFF_ARCHIVED)
  - `archived_by`: ForeignKey to User who archived
  - `is_archived` property: Convenience check
  - `archive()` and `unarchive()` methods: Soft-delete operations with idempotency
- **New periodic task** (`apps/trainerlab/tasks.py`): `archive_failed_trainerlab_simulations()` runs every 60 seconds and auto-archives failed simulations that:
  - Have status=FAILED
  - Reached terminal_at more than 300 seconds (5 minutes) ago
  - Are not yet archived
  - Have an associated TrainerSession (TrainerLab-owned only)
- **Celery beat schedule** (`config/celery.py`): Registered to run every 60 seconds

### Billing Exclusion
- **New `is_simulation_billable()` service** (`apps/simcore/services.py`): Returns False for FAILED simulations
- **Updated signal handler** (`apps/guards/signals.py`): `on_service_call_succeeded()` now checks billability and skips user/account usage records for failed simulations (session-level records are always preserved)

### Admin Interface
- **New admin registration** (`apps/trainerlab/admin.py`): `SimulationFailureRecordAdmin` with list display, filtering, search, and read-only fields for operational review

### API Updates
- **Schema updates** (`api/v1/schemas/trainerlab.py`): Added `archived_at` and `archived_reason` fields to `TrainerRunOut`
- **Endpoint filtering** (`api/v1/endpoints/trainerlab.py`): `list_trainer_sessions()` now excludes archived simulations from default queries

### Database Migrations
- **Simulation archival migration** (`apps/simcore/migrations/0009_simulation_archival.py`): Adds archival fields and index on (status, archived_at)
- **Failure record migration** (`apps/trainerlab/migrations/0022_simulationfailurerecord.py`): Creates SimulationFailureRecord table with indexes on (environment, lab_slug, created_at) and correlation_id

## Notable Implementation Details
- **Non-fatal error handling**: Both failure recording and email alerting catch and log exceptions to prevent upstream failures
- **Idempotency**: OneToOneField on SimulationFailureRecord and archive() method's early return ensure safe repeated calls
- **Grace period**: 300-second (5-minute) window allows for potential recovery attempts before arch

https://claude.ai/code/session_01NUrYF1GpjUHRiSJMfNcHCg