### PR TITLE
fix(trainerlab): add problem location labels

### DIFF
--- a/SimWorks/apps/common/static/common/js/simulation-events.d.ts
+++ b/SimWorks/apps/common/static/common/js/simulation-events.d.ts
@@ -305,7 +305,9 @@ export interface TrainerLabCauseFields {
     display_name?: string;
     description?: string;
     anatomical_location?: string;
+    anatomical_location_label?: string;
     laterality?: string;
+    laterality_label?: string;
     injury_location?: string;
     injury_kind?: string;
     injury_location_label?: string;
@@ -401,7 +403,9 @@ export interface TrainerLabProblemFields {
     march_category?: string;
     march_category_label?: string;
     anatomical_location?: string;
+    anatomical_location_label?: string;
     laterality?: string;
+    laterality_label?: string;
     status: 'active' | 'treated' | 'controlled' | 'resolved';
     previous_status?: string;
     treated_at?: string | null;
@@ -480,7 +484,9 @@ export interface TrainerLabAssessmentFindingFields {
     severity?: 'low' | 'moderate' | 'high' | 'critical';
     target_problem_id?: number | null;
     anatomical_location?: string;
+    anatomical_location_label?: string;
     laterality?: string;
+    laterality_label?: string;
     metadata?: Record<string, unknown>;
 }
 

--- a/SimWorks/apps/trainerlab/event_payloads.py
+++ b/SimWorks/apps/trainerlab/event_payloads.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import UTC
 from functools import lru_cache
+import re
 from typing import Any
 
 from django.core.exceptions import SynchronousOnlyOperation
@@ -56,6 +57,50 @@ def _injury_label_maps() -> dict[str, dict[str, str]]:
     }
 
 
+def _humanize_code(value: str) -> str:
+    normalized = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", value)
+    normalized = normalized.replace("_", " ").replace("-", " ").strip()
+    if not normalized:
+        return ""
+    return " ".join(normalized.split()).title()
+
+
+def _anatomical_location_label(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+
+    key = value.strip()
+    location_labels = _injury_label_maps()["injury_location"]
+    return (
+        location_labels.get(key)
+        or location_labels.get(key.upper())
+        or location_labels.get(key.lower())
+        or _humanize_code(key)
+    )
+
+
+def _laterality_label(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    key = value.strip().lower()
+    return {
+        "left": "Left",
+        "right": "Right",
+        "bilateral": "Bilateral",
+        "midline": "Midline",
+        "none": "None",
+    }.get(key, _humanize_code(value))
+
+
+def _enrich_anatomical_labels(payload: dict[str, Any]) -> None:
+    if "anatomical_location" in payload:
+        payload["anatomical_location_label"] = _anatomical_location_label(
+            payload.get("anatomical_location")
+        )
+    if "laterality" in payload:
+        payload["laterality_label"] = _laterality_label(payload.get("laterality"))
+
+
 def _event_timestamp_iso(obj: Any) -> str | None:
     timestamp = getattr(obj, "timestamp", None)
     if timestamp is None:
@@ -106,6 +151,7 @@ def _enrich_structured_intervention(payload: dict[str, Any]) -> bool:
 def enrich_trainer_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
     enriched = dict(payload or {})
     _enrich_injury_labels(enriched)
+    _enrich_anatomical_labels(enriched)
     _enrich_structured_intervention(enriched)
     return enriched
 

--- a/SimWorks/apps/trainerlab/event_payloads.py
+++ b/SimWorks/apps/trainerlab/event_payloads.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from django.core.exceptions import SynchronousOnlyOperation
 
-from .injury_dictionary import get_injury_dictionary_choices
+from .injury_dictionary import get_injury_dictionary_choices, get_injury_location_label
 from .intervention_dictionary import get_intervention_label, get_intervention_site_label
 from .models import (
     ETCO2,
@@ -69,14 +69,10 @@ def _anatomical_location_label(value: Any) -> str:
     if not isinstance(value, str) or not value.strip():
         return ""
 
-    key = value.strip()
-    location_labels = _injury_label_maps()["injury_location"]
-    return (
-        location_labels.get(key)
-        or location_labels.get(key.upper())
-        or location_labels.get(key.lower())
-        or _humanize_code(key)
-    )
+    try:
+        return get_injury_location_label(value)
+    except ValueError:
+        return _humanize_code(value)
 
 
 def _laterality_label(value: Any) -> str:

--- a/SimWorks/apps/trainerlab/injury_dictionary.py
+++ b/SimWorks/apps/trainerlab/injury_dictionary.py
@@ -12,6 +12,7 @@ _KNOWN_CATEGORY_ALIASES: dict[str, str] = {"PFC": "PC"}
 __all__ = [
     "build_injury_codebook_instruction",
     "get_injury_dictionary_choices",
+    "get_injury_location_label",
     "get_injury_mapping_warnings",
     "normalize_injury_category",
     "normalize_injury_kind",
@@ -179,6 +180,11 @@ def normalize_injury_location(value: Any) -> str:
 
 def normalize_injury_kind(value: Any) -> str:
     return _resolve_choice(_build_bundle().kind, value)
+
+
+def get_injury_location_label(value: Any) -> str:
+    code = normalize_injury_location(value)
+    return _build_bundle().location.code_to_label[code]
 
 
 def get_injury_dictionary_choices() -> dict[str, list[tuple[str, str]]]:

--- a/tests/common/test_frontend_event_contracts.py
+++ b/tests/common/test_frontend_event_contracts.py
@@ -44,6 +44,8 @@ def test_load_older_button_visibility_is_top_and_failure_bound():
 def test_trainerlab_event_contract_includes_friendly_labels():
     source = _read("SimWorks/apps/common/static/common/js/simulation-events.d.ts")
     assert "march_category_label?: string;" in source
+    assert "anatomical_location_label?: string;" in source
+    assert "laterality_label?: string;" in source
     assert "injury_location_label?: string;" in source
     assert "injury_kind_label?: string;" in source
     assert "intervention_label?: string;" in source

--- a/tests/simulation/test_trainerlab_event_payload_labels.py
+++ b/tests/simulation/test_trainerlab_event_payload_labels.py
@@ -16,6 +16,16 @@ def test_get_injury_location_label_resolves_canonical_codes_and_labels():
     assert get_injury_location_label("left lower leg") == "Left Lower Leg"
 
 
+def test_enrich_trainer_payload_humanizes_separator_location_values():
+    underscore_payload = enrich_trainer_payload({"anatomical_location": "left_lower_leg"})
+    hyphen_payload = enrich_trainer_payload({"anatomical_location": "left-lower-leg"})
+
+    assert underscore_payload["anatomical_location"] == "left_lower_leg"
+    assert underscore_payload["anatomical_location_label"] == "Left Lower Leg"
+    assert hyphen_payload["anatomical_location"] == "left-lower-leg"
+    assert hyphen_payload["anatomical_location_label"] == "Left Lower Leg"
+
+
 def test_enrich_trainer_payload_adds_anatomy_and_laterality_labels_from_code():
     payload = enrich_trainer_payload(
         {

--- a/tests/simulation/test_trainerlab_event_payload_labels.py
+++ b/tests/simulation/test_trainerlab_event_payload_labels.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+
+from apps.trainerlab.event_payloads import (
+    enrich_trainer_payload,
+    serialize_assessment_finding_summary,
+    serialize_cause_snapshot,
+    serialize_problem_snapshot,
+)
+
+
+def test_enrich_trainer_payload_adds_anatomy_and_laterality_labels():
+    payload = enrich_trainer_payload(
+        {
+            "anatomical_location": "Lll",
+            "laterality": "left",
+        }
+    )
+
+    assert payload["anatomical_location"] == "Lll"
+    assert payload["anatomical_location_label"] == "Left Lower Leg"
+    assert payload["laterality"] == "left"
+    assert payload["laterality_label"] == "Left"
+
+
+def test_enrich_trainer_payload_humanizes_unknown_anatomy_values():
+    payload = enrich_trainer_payload(
+        {
+            "anatomical_location": "left-lower-calf",
+            "laterality": "patientRight",
+        }
+    )
+
+    assert payload["anatomical_location_label"] == "Left Lower Calf"
+    assert payload["laterality_label"] == "Patient Right"
+
+
+def test_enrich_trainer_payload_uses_empty_labels_for_empty_raw_values():
+    payload = enrich_trainer_payload(
+        {
+            "anatomical_location": "",
+            "laterality": None,
+        }
+    )
+
+    assert payload["anatomical_location_label"] == ""
+    assert payload["laterality_label"] == ""
+
+
+def test_problem_snapshot_includes_anatomy_and_laterality_labels():
+    problem = SimpleNamespace(
+        id=101,
+        is_active=True,
+        kind="hemorrhage",
+        code="HEMORRHAGE",
+        slug="hemorrhage",
+        title="Hemorrhage",
+        display_name="Hemorrhage",
+        description="Active bleeding",
+        severity="critical",
+        march_category="M",
+        anatomical_location="LLL",
+        laterality="left",
+        status="active",
+        previous_status="",
+        treated_at=None,
+        controlled_at=None,
+        resolved_at=None,
+        cause_id=12,
+        cause_kind="injury",
+        parent_problem_id=None,
+        triggering_intervention_id=None,
+        adjudication_reason="",
+        adjudication_rule_id="",
+        metadata_json={},
+        source="system",
+        timestamp=None,
+    )
+
+    payload = serialize_problem_snapshot(problem)
+
+    assert payload["anatomical_location"] == "LLL"
+    assert payload["anatomical_location_label"] == "Left Lower Leg"
+    assert payload["laterality"] == "left"
+    assert payload["laterality_label"] == "Left"
+
+
+def test_cause_and_finding_summaries_include_anatomy_labels():
+    cause = SimpleNamespace(
+        id=201,
+        is_active=True,
+        cause_kind="injury",
+        kind="laceration",
+        code="LAC",
+        slug="laceration",
+        title="Laceration",
+        display_name="Laceration",
+        description="Leg laceration",
+        anatomical_location="LLL",
+        laterality="left",
+        metadata_json={},
+        source="system",
+        timestamp=None,
+        injury_location="LLL",
+        injury_kind="LAC",
+    )
+    finding = SimpleNamespace(
+        id=301,
+        is_active=True,
+        kind="bleeding",
+        code="BLEEDING",
+        slug="bleeding",
+        title="Bleeding",
+        display_name="Bleeding",
+        description="Bleeding from wound",
+        status="present",
+        severity="critical",
+        target_problem_id=101,
+        anatomical_location="LLL",
+        laterality="left",
+        metadata_json={},
+        source="system",
+        timestamp=None,
+    )
+
+    cause_payload = serialize_cause_snapshot(cause)
+    finding_payload = serialize_assessment_finding_summary(finding)
+
+    assert cause_payload["anatomical_location_label"] == "Left Lower Leg"
+    assert cause_payload["laterality_label"] == "Left"
+    assert finding_payload["anatomical_location_label"] == "Left Lower Leg"
+    assert finding_payload["laterality_label"] == "Left"

--- a/tests/simulation/test_trainerlab_event_payload_labels.py
+++ b/tests/simulation/test_trainerlab_event_payload_labels.py
@@ -6,20 +6,49 @@ from apps.trainerlab.event_payloads import (
     serialize_cause_snapshot,
     serialize_problem_snapshot,
 )
+from apps.trainerlab.injury_dictionary import get_injury_location_label
 
 
-def test_enrich_trainer_payload_adds_anatomy_and_laterality_labels():
+def test_get_injury_location_label_resolves_canonical_codes_and_labels():
+    assert get_injury_location_label("LLL") == "Left Lower Leg"
+    assert get_injury_location_label("Lll") == "Left Lower Leg"
+    assert get_injury_location_label("Left Lower Leg") == "Left Lower Leg"
+    assert get_injury_location_label("left lower leg") == "Left Lower Leg"
+
+
+def test_enrich_trainer_payload_adds_anatomy_and_laterality_labels_from_code():
     payload = enrich_trainer_payload(
         {
-            "anatomical_location": "Lll",
+            "anatomical_location": "LLL",
             "laterality": "left",
         }
     )
 
-    assert payload["anatomical_location"] == "Lll"
+    assert payload["anatomical_location"] == "LLL"
     assert payload["anatomical_location_label"] == "Left Lower Leg"
     assert payload["laterality"] == "left"
     assert payload["laterality_label"] == "Left"
+
+
+def test_enrich_trainer_payload_adds_anatomy_labels_from_mixed_case_code():
+    payload = enrich_trainer_payload({"anatomical_location": "Lll"})
+
+    assert payload["anatomical_location"] == "Lll"
+    assert payload["anatomical_location_label"] == "Left Lower Leg"
+
+
+def test_enrich_trainer_payload_adds_anatomy_labels_from_canonical_label():
+    payload = enrich_trainer_payload({"anatomical_location": "Left Lower Leg"})
+
+    assert payload["anatomical_location"] == "Left Lower Leg"
+    assert payload["anatomical_location_label"] == "Left Lower Leg"
+
+
+def test_enrich_trainer_payload_adds_anatomy_labels_from_lowercase_label():
+    payload = enrich_trainer_payload({"anatomical_location": "left lower leg"})
+
+    assert payload["anatomical_location"] == "left lower leg"
+    assert payload["anatomical_location_label"] == "Left Lower Leg"
 
 
 def test_enrich_trainer_payload_humanizes_unknown_anatomy_values():
@@ -30,6 +59,7 @@ def test_enrich_trainer_payload_humanizes_unknown_anatomy_values():
         }
     )
 
+    assert payload["anatomical_location"] == "left-lower-calf"
     assert payload["anatomical_location_label"] == "Left Lower Calf"
     assert payload["laterality_label"] == "Patient Right"
 


### PR DESCRIPTION
## Summary
- Add `anatomical_location_label` and `laterality_label` enrichment for TrainerLab payloads in the shared backend serializer path
- Reuse the canonical injury location dictionary with safe humanized fallbacks for unknown values
- Extend the typed event contract for causes, problems, and assessment findings
- Add backend tests covering enrichment and serializer output

## Testing
- Unit tests added for payload enrichment and snapshot serialization
- Contract test updated to cover the new label fields