### PR TITLE
Fix async context issues in patient instruction rendering

### DIFF
--- a/SimWorks/apps/chatlab/orca/instructions/patient.py
+++ b/SimWorks/apps/chatlab/orca/instructions/patient.py
@@ -62,7 +62,9 @@ class PatientModifierInstruction(BaseInstruction):
             simulation_id = self.context.get("simulation_id")
             if simulation_id:
                 try:
-                    simulation = await Simulation.objects.aget(pk=simulation_id)
+                    simulation = await Simulation.objects.select_related("user").aget(
+                        pk=simulation_id
+                    )
                     self.context["simulation"] = simulation
                 except (TypeError, ValueError, ObjectDoesNotExist):
                     return ""
@@ -107,6 +109,18 @@ class PatientRecentScenarioHistoryInstruction(BaseInstruction):
     async def render_instruction(self) -> str:
         context = self.context
         user = context.get("user")
+
+        if user is None:
+            # Resolve via user_id primitive first to avoid lazy FK access on a cached simulation.
+            user_id = context.get("user_id")
+            if user_id:
+                from django.contrib.auth import get_user_model
+
+                try:
+                    user = await get_user_model().objects.aget(pk=user_id)
+                    context["user"] = user
+                except Exception:
+                    user = None
 
         if user is None:
             simulation = context.get("simulation")

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -33,4 +33,13 @@ else
   echo "Skipping default role creation."
 fi
 
+if [ "${DJANGO_SYNC_LAB_MODIFIERS:-0}" = "1" ]; then
+  echo
+  echo "Syncing lab modifier catalogs..."
+  python manage.py sync_lab_modifiers --lab chatlab
+else
+  echo
+  echo "Skipping lab modifier sync."
+fi
+
 exec "$@"

--- a/tests/chatlab/test_patient_services.py
+++ b/tests/chatlab/test_patient_services.py
@@ -435,3 +435,87 @@ class TestPatientRecentScenarioHistoryInstruction:
 
         assert '("Right lower quadrant pain", "Appendicitis")' in rendered
         assert '("Flank pain and fever", "Pyelonephritis")' not in rendered
+
+    def test_resolves_user_via_user_id_when_bare_simulation_cached_in_context(
+        self,
+        history_user,
+    ):
+        """Regression: PatientRecentScenarioHistoryInstruction must not trigger lazy FK access.
+
+        In production, PatientModifierInstruction (order=5) runs before this instruction and
+        caches the simulation in context.  Before the fix, if that cached simulation was fetched
+        without select_related("user"), accessing simulation.user inside an async service call
+        would raise SynchronousOnlyOperation.
+
+        This test verifies the instruction resolves the user via the user_id context primitive
+        (Fix 2) so it never needs to traverse the simulation.user FK at all.
+        """
+        from apps.simcore.models import Simulation
+
+        current_simulation = Simulation.objects.create(
+            user=history_user,
+            diagnosis="Current Diagnosis",
+            chief_complaint="Current Complaint",
+            sim_patient_full_name="Current Patient",
+        )
+        recent_simulation = Simulation.objects.create(
+            user=history_user,
+            diagnosis="Pneumonia",
+            chief_complaint="Shortness of breath",
+            sim_patient_full_name="Recent Patient",
+        )
+        _set_start_timestamp(recent_simulation, days_ago=15)
+
+        # Simulate what PatientModifierInstruction used to do before Fix 1:
+        # fetch simulation bare (no select_related) and cache it to context.
+        bare_simulation = Simulation.objects.get(pk=current_simulation.pk)
+
+        service = GenerateInitialResponse(
+            context={
+                "simulation_id": current_simulation.id,
+                "user_id": history_user.id,
+                "simulation": bare_simulation,  # cached without select_related("user")
+            }
+        )
+
+        # The instruction must resolve user via user_id, not via bare_simulation.user.
+        rendered = async_to_sync(PatientRecentScenarioHistoryInstruction.render_instruction)(
+            service
+        )
+
+        assert '("Shortness of breath", "Pneumonia")' in rendered
+
+    def test_patient_modifier_instruction_caches_simulation_with_user_preloaded(
+        self,
+        history_user,
+    ):
+        """Regression: PatientModifierInstruction must select_related("user") when caching.
+
+        Before Fix 1, PatientModifierInstruction cached a bare simulation (no select_related).
+        PatientRecentScenarioHistoryInstruction (order=80) would then try simulation.user on
+        that bare object inside an async context, causing SynchronousOnlyOperation in production.
+
+        This test verifies that after PatientModifierInstruction runs, the simulation stored in
+        context has the user FK already loaded (no lazy DB hit needed).
+        """
+        from apps.chatlab.orca.instructions import PatientModifierInstruction
+        from apps.simcore.models import Simulation
+
+        simulation = Simulation.objects.create(
+            user=history_user,
+            sim_patient_full_name="Test Patient",
+        )
+
+        service = GenerateInitialResponse(context={"simulation_id": simulation.id})
+
+        async_to_sync(PatientModifierInstruction.render_instruction)(service)
+
+        cached = service.context.get("simulation")
+        assert cached is not None, "PatientModifierInstruction must cache simulation in context"
+        # Accessing .user must not require a DB round-trip; verify the field descriptor
+        # does not indicate a deferred/non-loaded state.
+        assert cached.user_id == history_user.id
+        # If user was not select_related, cached.user would trigger a sync ORM query here.
+        # After Fix 1, it is pre-loaded so this access is safe.
+        assert cached.user is not None
+        assert cached.user.pk == history_user.pk


### PR DESCRIPTION
## Summary
This PR fixes synchronous-only operation errors that occur when patient instruction rendering happens in async contexts with cached simulation objects that lack preloaded foreign keys.

## Key Changes

- **PatientModifierInstruction**: Updated to use `select_related("user")` when caching the simulation object, ensuring the user FK is preloaded and avoids lazy access in async contexts.

- **PatientRecentScenarioHistoryInstruction**: Added fallback logic to resolve the user via the `user_id` context primitive instead of traversing the cached simulation's user FK, preventing lazy FK access in async service calls.

- **Docker entrypoint**: Added optional lab modifier catalog synchronization step (controlled by `DJANGO_SYNC_LAB_MODIFIERS` environment variable).

## Implementation Details

The fix addresses a regression where `PatientRecentScenarioHistoryInstruction` would trigger `SynchronousOnlyOperation` errors in production when:
1. `PatientModifierInstruction` cached a bare simulation (without `select_related("user")`)
2. The instruction later tried to access `simulation.user` inside an async context

The solution uses a two-pronged approach:
- **Fix 1**: `PatientModifierInstruction` now eagerly loads the user relationship when caching
- **Fix 2**: `PatientRecentScenarioHistoryInstruction` resolves the user via `user_id` context primitive first, avoiding FK traversal altogether

Both test cases verify these fixes prevent lazy FK access in async contexts.

https://claude.ai/code/session_015aH7mRGVorQFF2CQPDyj6t