### PR TITLE
Suppress self typing indicators (backend + web guards)

### DIFF
--- a/SimWorks/apps/chatlab/consumers.py
+++ b/SimWorks/apps/chatlab/consumers.py
@@ -308,7 +308,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
         await self._send_envelope(envelope)
 
-
     def _is_self_typing_event(self, envelope: dict[str, Any]) -> bool:
         event_type = str(envelope.get("event_type") or "")
         if event_type not in {TYPING_STARTED, TYPING_STOPPED}:
@@ -329,19 +328,19 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 if int(sender_id) == int(current_user_id):
                     return True
             except (TypeError, ValueError):
+                # Non-integer IDs may arrive from older clients; fall through to UUID/email checks.
                 pass
 
         actor_user_uuid = payload.get("actor_user_uuid")
-        if actor_user_uuid and current_user_uuid:
-            if str(actor_user_uuid) == str(current_user_uuid):
-                return True
+        if actor_user_uuid and current_user_uuid and str(actor_user_uuid) == str(current_user_uuid):
+            return True
 
         payload_user = payload.get("user")
-        if payload_user and current_user_email:
-            if str(payload_user).lower() == str(current_user_email).lower():
-                return True
-
-        return False
+        return bool(
+            payload_user
+            and current_user_email
+            and str(payload_user).lower() == str(current_user_email).lower()
+        )
 
     async def _handle_session_event(self, inbound) -> None:
         if self.session_established:

--- a/SimWorks/apps/chatlab/consumers.py
+++ b/SimWorks/apps/chatlab/consumers.py
@@ -291,11 +291,57 @@ class ChatConsumer(AsyncWebsocketConsumer):
             )
             return
 
+        if self._is_self_typing_event(envelope):
+            logger.debug(
+                "chatlab.ws.typing_self_suppressed",
+                simulation_id=self.simulation_id,
+                user_id=getattr(self.scope.get("user"), "id", None),
+                channel_name=self.channel_name,
+                event_type=envelope.get("event_type"),
+                conversation_id=(envelope.get("payload") or {}).get("conversation_id"),
+            )
+            return
+
         if self.is_replaying:
             self.deferred_transient_events.append(envelope)
             return
 
         await self._send_envelope(envelope)
+
+
+    def _is_self_typing_event(self, envelope: dict[str, Any]) -> bool:
+        event_type = str(envelope.get("event_type") or "")
+        if event_type not in {TYPING_STARTED, TYPING_STOPPED}:
+            return False
+
+        payload = envelope.get("payload") or {}
+        if payload.get("actor_type") != "user":
+            return False
+
+        scope_user = self.scope.get("user")
+        current_user_id = getattr(scope_user, "id", None)
+        current_user_uuid = getattr(scope_user, "uuid", None)
+        current_user_email = getattr(scope_user, "email", None)
+
+        sender_id = payload.get("sender_id") or payload.get("actor_user_id")
+        if sender_id is not None and current_user_id is not None:
+            try:
+                if int(sender_id) == int(current_user_id):
+                    return True
+            except (TypeError, ValueError):
+                pass
+
+        actor_user_uuid = payload.get("actor_user_uuid")
+        if actor_user_uuid and current_user_uuid:
+            if str(actor_user_uuid) == str(current_user_uuid):
+                return True
+
+        payload_user = payload.get("user")
+        if payload_user and current_user_email:
+            if str(payload_user).lower() == str(current_user_email).lower():
+                return True
+
+        return False
 
     async def _handle_session_event(self, inbound) -> None:
         if self.session_established:
@@ -584,10 +630,16 @@ class ChatConsumer(AsyncWebsocketConsumer):
         user_label = getattr(scope_user, "email", None) or SYSTEM_USER
         display_initials = await sync_to_async(get_user_initials)(user_label)
         event_type = TYPING_STARTED if started else TYPING_STOPPED
+        user_id = getattr(scope_user, "id", None)
+        user_uuid = getattr(scope_user, "uuid", None)
         event_payload = {
             "conversation_id": payload.get("conversation_id"),
             "user": user_label,
             "display_initials": display_initials,
+            "actor_type": "user",
+            "sender_id": user_id,
+            "actor_user_id": user_id,
+            "actor_user_uuid": str(user_uuid) if user_uuid else None,
         }
         envelope = build_realtime_envelope(
             event_type,
@@ -626,6 +678,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 "conversation_id": None,
                 "user": SYSTEM_USER,
                 "display_initials": self.simulation.sim_patient_initials,
+                "actor_type": "system",
+                "sender_id": None,
+                "actor_user_id": None,
+                "actor_user_uuid": None,
             },
             correlation_id=correlation_id,
         )

--- a/SimWorks/apps/chatlab/static/chatlab/js/chat.js
+++ b/SimWorks/apps/chatlab/static/chatlab/js/chat.js
@@ -1213,28 +1213,40 @@ function ChatManager(simulation_id, currentUserId, currentUserEmail) {
         },
 
         _typingUserKey(userData) {
-            return userData?.actorUserUuid || userData?.actorUserId || userData?.senderId || userData?.user || null;
+            return (
+                userData?.actor_user_uuid ||
+                userData?.actorUserUuid ||
+                userData?.actor_user_id ||
+                userData?.actorUserId ||
+                userData?.sender_id ||
+                userData?.senderId ||
+                userData?.user ||
+                null
+            );
         },
 
         removeTypingUser(data) {
-            const conversationId = this._normalizeConversationId(data?.conversation_id ?? this.activeConversationId);
+            const conversationId = this._normalizeConversationId(
+                data?.conversation_id ?? this.activeConversationId
+            );
             if (!conversationId) return;
 
-            const existingUsers = this.typingUsersByConversation[conversationId] || [];
-            const targetSenderId = data?.sender_id ?? data?.actor_user_id ?? data?.senderId ?? data?.actorUserId ?? null;
-            const targetUser = data?.user || null;
-            const nextUsers = existingUsers.filter((u) => {
-                if (targetSenderId !== null && targetSenderId !== undefined) {
-                    return String(u.senderId ?? u.actorUserId ?? '') !== String(targetSenderId);
-                }
-                return u.user !== targetUser;
-            });
+            const targetKey = this._typingUserKey(data);
+            if (!targetKey) return;
 
-            this.typingUsersByConversation = {
-                ...this.typingUsersByConversation,
-                [conversationId]: nextUsers,
-            };
-            if (!nextUsers.length) delete this.typingUsersByConversation[conversationId];
+            const existingUsers = this.typingUsersByConversation[conversationId] || [];
+            const nextUsers = existingUsers.filter(
+                user => this._typingUserKey(user) !== targetKey
+            );
+
+            const nextByConversation = { ...this.typingUsersByConversation };
+            if (nextUsers.length) {
+                nextByConversation[conversationId] = nextUsers;
+            } else {
+                delete nextByConversation[conversationId];
+            }
+
+            this.typingUsersByConversation = nextByConversation;
         },
 
         updateTypingUsers(data, started = true) {

--- a/SimWorks/apps/chatlab/static/chatlab/js/chat.js
+++ b/SimWorks/apps/chatlab/static/chatlab/js/chat.js
@@ -141,7 +141,8 @@ function ChatManager(simulation_id, currentUserId, currentUserEmail) {
 
         get activeTypingUsers() {
             if (!this.activeConversationId) return [];
-            return this.typingUsersByConversation[this.activeConversationId] || [];
+            const users = this.typingUsersByConversation[this.activeConversationId] || [];
+            return users.filter(user => !this._isSelfTypingPayload(user));
         },
 
         init() {
@@ -564,13 +565,37 @@ function ChatManager(simulation_id, currentUserId, currentUserEmail) {
             });
         },
 
-        handleTyping(data, started) {
+        _isSelfTypingPayload(data) {
+            if (!data) return false;
+
+            const senderIdRaw = data.sender_id ?? data.actor_user_id ?? data.senderId ?? data.actorUserId;
+            const senderId = Number.parseInt(senderIdRaw, 10);
+
             if (
-                data.user !== this.currentUserEmail &&
-                !(data.sender_id && Number.parseInt(data.sender_id, 10) === this.currentUserId)
+                Number.isFinite(senderId) &&
+                Number.isFinite(this.currentUserId) &&
+                senderId === this.currentUserId
             ) {
-                this.updateTypingUsers(data, started);
+                return true;
             }
+
+            const payloadUser = data.user ? String(data.user).toLowerCase() : '';
+            const currentEmail = this.currentUserEmail ? String(this.currentUserEmail).toLowerCase() : '';
+
+            if (payloadUser && currentEmail && payloadUser === currentEmail) {
+                return true;
+            }
+
+            return false;
+        },
+
+        handleTyping(data, started) {
+            if (this._isSelfTypingPayload(data)) {
+                this.removeTypingUser(data);
+                return;
+            }
+
+            this.updateTypingUsers(data, started);
         },
 
         handleSocketConnected() {
@@ -1187,22 +1212,58 @@ function ChatManager(simulation_id, currentUserId, currentUserEmail) {
             });
         },
 
+        _typingUserKey(userData) {
+            return userData?.actorUserUuid || userData?.actorUserId || userData?.senderId || userData?.user || null;
+        },
+
+        removeTypingUser(data) {
+            const conversationId = this._normalizeConversationId(data?.conversation_id ?? this.activeConversationId);
+            if (!conversationId) return;
+
+            const existingUsers = this.typingUsersByConversation[conversationId] || [];
+            const targetSenderId = data?.sender_id ?? data?.actor_user_id ?? data?.senderId ?? data?.actorUserId ?? null;
+            const targetUser = data?.user || null;
+            const nextUsers = existingUsers.filter((u) => {
+                if (targetSenderId !== null && targetSenderId !== undefined) {
+                    return String(u.senderId ?? u.actorUserId ?? '') !== String(targetSenderId);
+                }
+                return u.user !== targetUser;
+            });
+
+            this.typingUsersByConversation = {
+                ...this.typingUsersByConversation,
+                [conversationId]: nextUsers,
+            };
+            if (!nextUsers.length) delete this.typingUsersByConversation[conversationId];
+        },
+
         updateTypingUsers(data, started = true) {
             const conversationId = this._normalizeConversationId(
                 data.conversation_id ?? this.activeConversationId
             );
             if (!conversationId) return;
 
-            const displayInitials = data.display_initials || 'Unk';
+            const typingUser = {
+                user: data.user,
+                displayInitials: data.display_initials || data.displayInitials || 'Unk',
+                senderId: data.sender_id ?? data.actor_user_id ?? null,
+                actorUserId: data.actor_user_id ?? data.sender_id ?? null,
+                actorUserUuid: data.actor_user_uuid ?? null,
+                actorType: data.actor_type ?? 'user',
+            };
+            const typingKey = this._typingUserKey(typingUser);
             const existingUsers = this.typingUsersByConversation[conversationId] || [];
             let nextUsers = existingUsers;
 
             if (!started) {
-                nextUsers = existingUsers.filter(u => u.user !== data.user);
+                nextUsers = existingUsers.filter(u => this._typingUserKey(u) !== typingKey);
             } else {
-                const alreadyTyping = existingUsers.some(u => u.user === data.user);
-                if (!alreadyTyping) {
-                    nextUsers = [...existingUsers, { user: data.user, displayInitials }];
+                const existingIndex = existingUsers.findIndex(u => this._typingUserKey(u) === typingKey);
+                if (existingIndex >= 0) {
+                    nextUsers = [...existingUsers];
+                    nextUsers[existingIndex] = { ...nextUsers[existingIndex], ...typingUser };
+                } else {
+                    nextUsers = [...existingUsers, typingUser];
                 }
             }
 

--- a/SimWorks/apps/chatlab/templates/chatlab/partials/typing_indicator.html
+++ b/SimWorks/apps/chatlab/templates/chatlab/partials/typing_indicator.html
@@ -4,7 +4,7 @@
      x-cloak>
     <div id="indicator-wrapper"
          class="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs text-content-secondary shadow-sm">
-        <template x-for="user in activeTypingUsers" :key="user.user">
+        <template x-for="user in activeTypingUsers" :key="user.actorUserUuid || user.actorUserId || user.senderId || user.user">
             <div class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-jckfrt-olive/20 text-[10px] font-bold text-jckfrt-olive">
                 <span x-text="user.displayInitials"></span>
             </div>

--- a/tests/chatlab/test_consumers.py
+++ b/tests/chatlab/test_consumers.py
@@ -182,9 +182,24 @@ class TestChatConsumerContract:
                 "payload": {"conversation_id": 123},
             }
         )
-        typing_started = await receive_json(communicator)
+        with pytest.raises(asyncio.TimeoutError):
+            await receive_json(communicator, timeout=0.2)
+
+        observer = await connect_and_hello(simulation, user)
+        observer_ready = await receive_json(observer)
+        assert observer_ready["event_type"] == "session.ready"
+        await receive_json(observer)
+
+        typing_started = await receive_json(observer)
         assert typing_started["event_type"] == "typing.started"
         assert typing_started["payload"]["conversation_id"] == 123
+        assert typing_started["payload"]["actor_type"] == "user"
+        assert typing_started["payload"]["sender_id"] == user.id
+        assert typing_started["payload"]["actor_user_id"] == user.id
+        expected_uuid = str(user.uuid) if getattr(user, "uuid", None) else None
+        assert typing_started["payload"]["actor_user_uuid"] == expected_uuid
+        assert typing_started["payload"]["user"] == user.email
+        assert "display_initials" in typing_started["payload"]
 
         await communicator.send_json_to(
             {
@@ -192,11 +207,12 @@ class TestChatConsumerContract:
                 "payload": {"conversation_id": 123},
             }
         )
-        typing_stopped = await receive_json(communicator)
+        typing_stopped = await receive_json(observer)
         assert typing_stopped["event_type"] == "typing.stopped"
         assert typing_stopped["payload"]["conversation_id"] == 123
 
         await communicator.disconnect()
+        await observer.disconnect()
 
     async def test_resume_replays_durable_events_after_anchor_and_excludes_anchor(self):
         simulation, user = await create_simulation_and_user()
@@ -265,6 +281,70 @@ class TestChatConsumerContract:
         assert response["payload"]["reason"] == "unknown_last_event_id"
 
         await communicator.disconnect()
+
+
+    async def test_chatlab_transient_suppresses_self_user_typing(self):
+        simulation, user = await create_simulation_and_user(in_progress=True)
+        consumer = ChatConsumer()
+        consumer.scope = {"user": user}
+        consumer.simulation_id = simulation.id
+        consumer.channel_name = "test-channel"
+        consumer._send_envelope = AsyncMock()
+
+        envelope = chat_realtime.build_realtime_envelope(
+            chat_realtime.TYPING_STARTED,
+            {
+                "conversation_id": 123,
+                "actor_type": "user",
+                "sender_id": user.id,
+                "actor_user_id": user.id,
+                "actor_user_uuid": str(getattr(user, "uuid", "")) if getattr(user, "uuid", None) else None,
+                "user": user.email,
+                "display_initials": "TU",
+            },
+        )
+
+        await consumer.chatlab_transient({"event": envelope})
+
+        consumer._send_envelope.assert_not_awaited()
+
+    async def test_chatlab_transient_allows_system_typing(self):
+        simulation, user = await create_simulation_and_user(in_progress=True)
+        consumer = ChatConsumer()
+        consumer.scope = {"user": user}
+        consumer.simulation_id = simulation.id
+        consumer.channel_name = "test-channel"
+        consumer._send_envelope = AsyncMock()
+
+        envelope = chat_realtime.build_realtime_envelope(
+            chat_realtime.TYPING_STARTED,
+            {
+                "conversation_id": None,
+                "actor_type": "system",
+                "sender_id": None,
+                "actor_user_id": None,
+                "actor_user_uuid": None,
+                "user": "system@medsim.local",
+                "display_initials": "TP",
+            },
+        )
+
+        await consumer.chatlab_transient({"event": envelope})
+
+        consumer._send_envelope.assert_awaited_once()
+
+    async def test_chatlab_transient_non_typing_events_unchanged(self):
+        simulation, user = await create_simulation_and_user(in_progress=True)
+        consumer = ChatConsumer()
+        consumer.scope = {"user": user}
+        consumer.simulation_id = simulation.id
+        consumer.channel_name = "test-channel"
+        consumer._send_envelope = AsyncMock()
+
+        envelope = chat_realtime.build_realtime_envelope(chat_realtime.PING, {"ok": True})
+        await consumer.chatlab_transient({"event": envelope})
+
+        consumer._send_envelope.assert_not_awaited()
 
     async def test_resume_deduplicates_live_events_buffered_during_replay(self, monkeypatch):
         simulation, user = await create_simulation_and_user()

--- a/tests/chatlab/test_consumers.py
+++ b/tests/chatlab/test_consumers.py
@@ -167,51 +167,76 @@ class TestChatConsumerContract:
         await communicator.disconnect()
 
     async def test_typing_events_are_live_only_and_enveloped(self):
-        simulation, user = await create_simulation_and_user(in_progress=True)
-        communicator = await connect_and_hello(simulation, user)
+        from django.contrib.auth import get_user_model
 
-        ready = await receive_json(communicator)
-        assert ready["event_type"] == "session.ready"
+        simulation, sender_user = await create_simulation_and_user(in_progress=True)
 
-        initial_typing = await receive_json(communicator)
+        User = get_user_model()
+        observer_user = await User.objects.acreate(
+            email=f"chatws_observer_{uuid4().hex[:8]}@test.com",
+            role=sender_user.role,
+            is_staff=True,
+        )
+
+        sender = await connect_and_hello(simulation, sender_user)
+        sender_ready = await receive_json(sender)
+        assert sender_ready["event_type"] == "session.ready"
+
+        # In-progress simulations with no messages emit initial system typing on session hello.
+        initial_typing = await receive_json(sender)
         assert initial_typing["event_type"] == "typing.started"
+        assert initial_typing["payload"]["actor_type"] == "system"
 
-        await communicator.send_json_to(
+        observer = await connect_and_hello(simulation, observer_user)
+        observer_ready = await receive_json(observer)
+        assert observer_ready["event_type"] == "session.ready"
+
+        observer_initial_typing = await receive_json(observer)
+        assert observer_initial_typing["event_type"] == "typing.started"
+        assert observer_initial_typing["payload"]["actor_type"] == "system"
+
+        sender_observer_initial_typing = await receive_json(sender)
+        assert sender_observer_initial_typing["event_type"] == "typing.started"
+        assert sender_observer_initial_typing["payload"]["actor_type"] == "system"
+
+        await sender.send_json_to(
             {
                 "event_type": "typing.started",
                 "payload": {"conversation_id": 123},
             }
         )
-        with pytest.raises(asyncio.TimeoutError):
-            await receive_json(communicator, timeout=0.2)
 
-        observer = await connect_and_hello(simulation, user)
-        observer_ready = await receive_json(observer)
-        assert observer_ready["event_type"] == "session.ready"
-        await receive_json(observer)
+        with pytest.raises(asyncio.TimeoutError):
+            await receive_json(sender, timeout=0.2)
 
         typing_started = await receive_json(observer)
         assert typing_started["event_type"] == "typing.started"
         assert typing_started["payload"]["conversation_id"] == 123
         assert typing_started["payload"]["actor_type"] == "user"
-        assert typing_started["payload"]["sender_id"] == user.id
-        assert typing_started["payload"]["actor_user_id"] == user.id
-        expected_uuid = str(user.uuid) if getattr(user, "uuid", None) else None
+        assert typing_started["payload"]["sender_id"] == sender_user.id
+        assert typing_started["payload"]["actor_user_id"] == sender_user.id
+        expected_uuid = str(sender_user.uuid) if getattr(sender_user, "uuid", None) else None
         assert typing_started["payload"]["actor_user_uuid"] == expected_uuid
-        assert typing_started["payload"]["user"] == user.email
+        assert typing_started["payload"]["user"] == sender_user.email
         assert "display_initials" in typing_started["payload"]
 
-        await communicator.send_json_to(
+        await sender.send_json_to(
             {
                 "event_type": "typing.stopped",
                 "payload": {"conversation_id": 123},
             }
         )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await receive_json(sender, timeout=0.2)
+
         typing_stopped = await receive_json(observer)
         assert typing_stopped["event_type"] == "typing.stopped"
         assert typing_stopped["payload"]["conversation_id"] == 123
+        assert typing_stopped["payload"]["actor_type"] == "user"
+        assert typing_stopped["payload"]["sender_id"] == sender_user.id
 
-        await communicator.disconnect()
+        await sender.disconnect()
         await observer.disconnect()
 
     async def test_resume_replays_durable_events_after_anchor_and_excludes_anchor(self):
@@ -282,7 +307,6 @@ class TestChatConsumerContract:
 
         await communicator.disconnect()
 
-
     async def test_chatlab_transient_suppresses_self_user_typing(self):
         simulation, user = await create_simulation_and_user(in_progress=True)
         consumer = ChatConsumer()
@@ -298,7 +322,9 @@ class TestChatConsumerContract:
                 "actor_type": "user",
                 "sender_id": user.id,
                 "actor_user_id": user.id,
-                "actor_user_uuid": str(getattr(user, "uuid", "")) if getattr(user, "uuid", None) else None,
+                "actor_user_uuid": str(getattr(user, "uuid", ""))
+                if getattr(user, "uuid", None)
+                else None,
                 "user": user.email,
                 "display_initials": "TU",
             },
@@ -333,7 +359,7 @@ class TestChatConsumerContract:
 
         consumer._send_envelope.assert_awaited_once()
 
-    async def test_chatlab_transient_non_typing_events_unchanged(self):
+    async def test_chatlab_transient_rejects_non_transient_events(self):
         simulation, user = await create_simulation_and_user(in_progress=True)
         consumer = ChatConsumer()
         consumer.scope = {"user": user}


### PR DESCRIPTION
### Motivation

- Prevent the current authenticated user from seeing their own typing indicator in ChatLab and avoid echoing self-typing events back from the backend.  
- Preserve system/AI/simulated-patient typing indicators and keep payloads backward-compatible for existing web and iOS clients.  
- Prefer stable actor identity fields for robust filtering (ID/UUID) while retaining legacy `user` and `display_initials` fields.

### Description

- Add `_is_self_typing_event` helper on `ChatConsumer` that matches typing envelopes by `sender_id`/`actor_user_id`, then `actor_user_uuid`, then email, and only returns true for `actor_type == "user"`.  
- Use that helper in `chatlab_transient` before replay buffering to suppress self-typing transient events (so they are neither buffered nor sent).  
- Enrich `_handle_typing` payloads with `actor_type`, `sender_id`, `actor_user_id`, and `actor_user_uuid` while keeping `user` and `display_initials` for compatibility.  
- Explicitly mark system typing in `_broadcast_system_typing` with `actor_type: "system"` and null actor identity fields so system/simulated typing is never self-filtered.  
- Harden frontend `ChatManager` in `SimWorks/apps/chatlab/static/chatlab/js/chat.js` by adding `_isSelfTypingPayload`, `removeTypingUser`, stable typing user identity storage (UUID/ID/sender/email), filtering `activeTypingUsers` to exclude self payloads, and updating `updateTypingUsers` to use the stable key.  
- Update Alpine template key in `SimWorks/apps/chatlab/templates/chatlab/partials/typing_indicator.html` to `:key="user.actorUserUuid || user.actorUserId || user.senderId || user.user"`.  
- Update `tests/chatlab/test_consumers.py` to assert that the sending socket does not receive its own typing echo, to validate the new identity fields in user typing payloads, and to cover system typing passthrough and non-typing transient behavior.

### Testing

- Attempted to run `uv run pytest tests/chatlab/test_consumers.py --ds=tests.settings_test` in this environment but the run failed due to local Python/version resolver issues (project expects Python >=3.14 and the environment had a pyenv mismatch).  
- Attempted `uv run --python 3.14.0 pytest tests/chatlab/test_consumers.py --ds=tests.settings_test` but the environment hit a runtime/dependency failure (pydantic/typing internals against the provided 3.14 build); `uv run --python 3.13` is incompatible because the project requires `>=3.14`.  
- Updated/added automated tests in `tests/chatlab/test_consumers.py` covering: self-suppression (`test_chatlab_transient_suppresses_self_user_typing`), system passthrough (`test_chatlab_transient_allows_system_typing`), identity fields presence in typing payloads, and unchanged behavior for non-typing transients.  

If CI runs with the repository's required Python version and dependencies, the updated test suite should validate the behavior described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ac04f148833392b11f5a4cc340d0)