### PR TITLE
feat(chatlab): persist scenario ground truth

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Resolve and validate release metadata
         id: release_meta
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           INPUT_TAG: ${{ inputs.release_tag }}
         with:
@@ -139,7 +139,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
@@ -223,7 +223,7 @@ jobs:
 
       - name: Create GitHub deployment record
         id: deployment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           DEPLOY_ENVIRONMENT: production
           DEPLOY_REF: ${{ steps.release_ref.outputs.commit_sha }}
@@ -251,17 +251,17 @@ jobs:
             core.setOutput('deployment_id', String(res.data.id));
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
 
       - name: Resolve source digest from immutable tags
         id: source
@@ -413,7 +413,7 @@ jobs:
 
       - name: Mark deployment success
         if: ${{ success() }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
           DEPLOY_ENVIRONMENT: production
@@ -438,7 +438,7 @@ jobs:
 
       - name: Mark deployment failure
         if: ${{ failure() }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
           DEPLOY_ENVIRONMENT: production

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.ref }}
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create GitHub deployment record
         id: deployment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           DEPLOY_ENVIRONMENT: staging
         with:
@@ -94,10 +94,10 @@ jobs:
             core.setOutput('deployment_id', String(res.data.id));
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Build and push staging image
         id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
           file: docker/Dockerfile.prod
@@ -123,7 +123,7 @@ jobs:
             org.opencontainers.image.description=${{ steps.pyproject.outputs.description }}
 
       - name: Scan pushed image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
         with:
           scan-type: image
           image-ref: ${{ env.IMAGE }}:sha-${{ github.sha }}
@@ -134,7 +134,7 @@ jobs:
           exit-code: "1"
 
       - name: Generate CycloneDX SBOM
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
         with:
           scan-type: image
           image-ref: ${{ env.IMAGE }}:sha-${{ github.sha }}
@@ -152,14 +152,14 @@ jobs:
           retention-days: 14
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8
         with:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
 
       - name: Sign image digest with keyless OIDC
         env:
@@ -183,7 +183,7 @@ jobs:
 
       - name: Mark deployment success
         if: ${{ success() }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
           DEPLOY_ENVIRONMENT: staging
@@ -208,7 +208,7 @@ jobs:
 
       - name: Mark deployment failure
         if: ${{ failure() }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
           DEPLOY_ENVIRONMENT: staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       package_contracts: ${{ steps.filter.outputs.package_contracts }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
         with:
           filters: |
             package_contracts:
@@ -44,21 +44,21 @@ jobs:
       DJANGO_SETTINGS_MODULE: config.settings
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.14.3'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
         with:
           enable-cache: true
 
@@ -137,15 +137,15 @@ jobs:
       DJANGO_SETTINGS_MODULE: tests.settings_test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.14.3'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
         with:
           enable-cache: true
 
@@ -179,15 +179,15 @@ jobs:
       DJANGO_SETTINGS_MODULE: tests.settings_test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.14.3'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
         with:
           enable-cache: true
 
@@ -222,15 +222,15 @@ jobs:
       PYTEST_FAILURE_ARTIFACT_DIR: .pytest-failure-artifacts
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.14.3'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
         with:
           enable-cache: true
 
@@ -272,15 +272,15 @@ jobs:
       SIMWORKS_MIN_COVERAGE: '50'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.14.3'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
         with:
           enable-cache: true
 
@@ -368,7 +368,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1
         with:
           files: coverage-orchestrai.xml,coverage-orchestrai-django.xml,coverage-simworks.xml
           fail_ci_if_error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,20 +21,20 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
       - name: Run dependency review
         if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
         with:
           fail-on-severity: high
           show-openssf-scorecard: false
           fail-on-scopes: runtime
 
       - name: Run Trivy filesystem scan
-        uses: docker://aquasec/trivy:0.69.2
+        uses: docker://aquasec/trivy:0.74.0
         with:
           args: >-
             fs
@@ -46,7 +46,7 @@ jobs:
             .
 
       - name: Run gitleaks scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/SimWorks/apps/chatlab/orca/instructions/__init__.py
+++ b/SimWorks/apps/chatlab/orca/instructions/__init__.py
@@ -19,6 +19,7 @@ from .stitch import (
     StitchDebriefInstruction,
     StitchPersonaInstruction,
     StitchRoleInstruction,
+    StitchScenarioGroundTruthInstruction,
     StitchSchemaContractInstruction,
     StitchToneInstruction,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "StitchPersonaInstruction",
     "StitchReplyDetailInstruction",
     "StitchRoleInstruction",
+    "StitchScenarioGroundTruthInstruction",
     "StitchSchemaContractInstruction",
     "StitchToneInstruction",
 ]

--- a/SimWorks/apps/chatlab/orca/instructions/patient.yaml
+++ b/SimWorks/apps/chatlab/orca/instructions/patient.yaml
@@ -73,6 +73,10 @@ instructions:
     instruction: |
       ### Schema Contract
       - Follow the active response schema exactly; include all required top-level keys and no extras.
+      - For the initial response schema, include hidden top-level `diagnosis` and `chief_complaint`.
+      - `diagnosis` is the correct clinician-level scenario diagnosis.
+      - `chief_complaint` is the patient's presenting concern in concise terms.
+      - These fields are for server-side scenario tracking and must not be revealed in patient-facing `messages`.
       - Always include `llm_conditions_check` as concise key/value checks of rule compliance.
       - If `metadata` is present in the schema, include only clinically relevant structured details suitable for key-based upsert.
       - Metadata item examples:
@@ -90,6 +94,7 @@ instructions:
       - For the first turn, send exactly one natural opening patient message.
       - Briefly introduce the main symptoms or concern in a realistic way.
       - Keep the opening message non-diagnostic and concise.
+      - Keep patient-facing `messages` natural, non-diagnostic, and concise.
       - Do not front-load the history of present illness.
       - Do not volunteer associated symptoms, pertinent negatives, timelines, exposures, medications, past medical history, or risk factors unless they would naturally appear in an initial text from a lay patient.
       - Mention only background details that would naturally come up in an initial text.

--- a/SimWorks/apps/chatlab/orca/instructions/stitch.py
+++ b/SimWorks/apps/chatlab/orca/instructions/stitch.py
@@ -73,6 +73,42 @@ class StitchRoleInstruction(BaseInstruction):
     )
 
 
+@orca.instruction(order=55)
+class StitchScenarioGroundTruthInstruction(BaseInstruction):
+    namespace = "chatlab"
+    group = "stitch"
+
+    async def render_instruction(self) -> str:
+        simulation_id = self.context.get("simulation_id")
+
+        try:
+            sim = await Simulation.objects.aget(pk=simulation_id)
+        except (TypeError, ValueError, ObjectDoesNotExist):
+            return ""
+
+        diagnosis = (sim.diagnosis or "").strip()
+        chief_complaint = (sim.chief_complaint or "").strip()
+
+        if not diagnosis and not chief_complaint:
+            return (
+                "### Scenario Ground Truth\n"
+                "Persisted scenario ground truth is unavailable. "
+                "Do not present an inferred diagnosis as certain."
+            )
+
+        lines = ["### Scenario Ground Truth"]
+        if chief_complaint:
+            lines.append(f"- Chief complaint: {chief_complaint}")
+        if diagnosis:
+            lines.append(f"- Correct diagnosis: {diagnosis}")
+        lines.append(
+            "- Use this as the authoritative case answer when responding to learner "
+            "questions about diagnosis or case intent."
+        )
+        lines.append("- Use conversation history only for what the learner asked, said, or did.")
+        return "\n".join(lines)
+
+
 @orca.instruction(order=90)
 class StitchDebriefInstruction(BaseInstruction):
     namespace = "chatlab"

--- a/SimWorks/apps/chatlab/orca/instructions/stitch.py
+++ b/SimWorks/apps/chatlab/orca/instructions/stitch.py
@@ -97,10 +97,13 @@ class StitchScenarioGroundTruthInstruction(BaseInstruction):
             )
 
         lines = ["### Scenario Ground Truth"]
-        if chief_complaint:
-            lines.append(f"- Chief complaint: {chief_complaint}")
-        if diagnosis:
-            lines.append(f"- Correct diagnosis: {diagnosis}")
+        lines.append(f"- Chief complaint: {chief_complaint or 'unavailable'}")
+        lines.append(f"- Correct diagnosis: {diagnosis or 'unavailable'}")
+        if not diagnosis or not chief_complaint:
+            lines.append(
+                "- Persisted scenario ground truth is incomplete. Do not present an "
+                "unavailable inferred diagnosis or chief complaint as certain."
+            )
         lines.append(
             "- Use this as the authoritative case answer when responding to learner "
             "questions about diagnosis or case intent."

--- a/SimWorks/apps/chatlab/orca/schemas/patient.py
+++ b/SimWorks/apps/chatlab/orca/schemas/patient.py
@@ -61,6 +61,24 @@ class PatientInitialOutputSchema(PatientResponseBaseMixin):
     - Enables real-time UI updates when initial response is generated
     """
 
+    diagnosis: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description=(
+            "Hidden scenario ground-truth diagnosis. Do not include this in "
+            "patient-facing messages."
+        ),
+    )
+    chief_complaint: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description=(
+            "Hidden scenario chief complaint / presenting concern. Do not include this "
+            "in patient-facing messages unless naturally stated by the patient."
+        ),
+    )
     metadata: list[MetadataItem] = Field(
         ...,
         description="Patient demographics and initial metadata (polymorphic structure with 'kind' discriminator)",
@@ -111,6 +129,48 @@ class PatientInitialOutputSchema(PatientResponseBaseMixin):
                     "value": meta.value,
                 },
             )
+
+        diagnosis = (self.diagnosis or "").strip()
+        chief_complaint = (self.chief_complaint or "").strip()
+
+        if not diagnosis or not chief_complaint:
+            logger.warning(
+                "Initial response missing scenario ground truth: sim=%s diagnosis=%r chief_complaint=%r",
+                context.simulation_id,
+                diagnosis,
+                chief_complaint,
+            )
+            return
+
+        from apps.simcore.models import Simulation
+
+        sim = await Simulation.objects.aget(pk=context.simulation_id)
+
+        update_fields = []
+        if not sim.diagnosis:
+            sim.diagnosis = diagnosis
+            update_fields.append("diagnosis")
+        elif sim.diagnosis != diagnosis:
+            logger.warning(
+                "Initial response diagnosis differs from existing simulation diagnosis: sim=%s existing=%r new=%r",
+                context.simulation_id,
+                sim.diagnosis,
+                diagnosis,
+            )
+
+        if not sim.chief_complaint:
+            sim.chief_complaint = chief_complaint
+            update_fields.append("chief_complaint")
+        elif sim.chief_complaint != chief_complaint:
+            logger.warning(
+                "Initial response chief_complaint differs from existing simulation chief_complaint: sim=%s existing=%r new=%r",
+                context.simulation_id,
+                sim.chief_complaint,
+                chief_complaint,
+            )
+
+        if update_fields:
+            await sim.asave(update_fields=update_fields)
 
 
 class PatientReplyOutputSchema(PatientResponseBaseMixin):

--- a/SimWorks/apps/chatlab/orca/services/stitch.py
+++ b/SimWorks/apps/chatlab/orca/services/stitch.py
@@ -17,6 +17,7 @@ class GenerateStitchReply(PreviousResponseMixin, DjangoBaseService):
     instruction_refs: ClassVar[list[str]] = [
         "chatlab.stitch.StitchPersonaInstruction",
         "chatlab.stitch.StitchRoleInstruction",
+        "chatlab.stitch.StitchScenarioGroundTruthInstruction",
         "chatlab.stitch.StitchConversationContextInstruction",
         "chatlab.stitch.StitchDebriefInstruction",
         "chatlab.stitch.StitchSchemaContractInstruction",

--- a/SimWorks/apps/simcore/orca/instructions/feedback.yaml
+++ b/SimWorks/apps/simcore/orca/instructions/feedback.yaml
@@ -7,8 +7,15 @@ instructions:
     instruction: |
       Evaluate the completed simulation and produce structured initial feedback.
 
-      You MUST base your feedback exclusively on the actual simulation transcript provided.
-      Do not invent actions, questions, treatments, diagnoses, findings, or omissions not present
+      Use the Scenario Ground Truth section as the authoritative source for the correct
+      diagnosis and chief complaint when present.
+      Use the transcript as the authoritative source for learner actions, questions,
+      omissions, treatment decisions, and communication.
+      Do not infer the correct diagnosis from the transcript when persisted scenario
+      ground truth is available.
+      If scenario ground truth is missing, explicitly state that limitation and avoid
+      presenting an inferred diagnosis as certain.
+      Do not invent actions, questions, treatments, findings, or omissions not present
       in the simulation record. Do not provide generic feedback.
 
       ### Narrative Requirements
@@ -35,6 +42,12 @@ instructions:
     instruction: |
       Provide a direct, concise answer to the learner's follow-up question.
       Keep coaching practical and tied to the completed simulation context.
+      Use persisted Scenario Ground Truth as the authoritative source for the correct
+      diagnosis and chief complaint when present.
+      Use the simulation transcript or prior context only for learner actions,
+      questions, omissions, treatment decisions, and communication.
+      If scenario ground truth is missing, explicitly state that limitation and avoid
+      presenting an inferred diagnosis as certain.
 
       ### Response Schema
       - Use GenerateFeedbackContinuationResponse.

--- a/SimWorks/apps/simcore/orca/services/feedback.py
+++ b/SimWorks/apps/simcore/orca/services/feedback.py
@@ -15,6 +15,31 @@ from ..mixins import FeedbackMixin  # Identity mixin for component discovery
 logger = logging.getLogger(__name__)
 
 
+def _scenario_ground_truth_context(simulation_id, sim) -> tuple[str, str, str]:
+    diagnosis = (getattr(sim, "diagnosis", None) or "").strip()
+    chief_complaint = (getattr(sim, "chief_complaint", None) or "").strip()
+
+    ground_truth_lines = []
+    if chief_complaint:
+        ground_truth_lines.append(f"Chief complaint: {chief_complaint}")
+    if diagnosis:
+        ground_truth_lines.append(f"Correct diagnosis: {diagnosis}")
+
+    if not diagnosis or not chief_complaint:
+        logger.warning(
+            "[feedback] simulation=%s missing persisted ground truth diagnosis=%r chief_complaint=%r",
+            simulation_id,
+            diagnosis,
+            chief_complaint,
+        )
+
+    ground_truth = "\n".join(ground_truth_lines) or (
+        "Scenario ground truth is unavailable. State this limitation; do not infer "
+        "the authoritative diagnosis as certain."
+    )
+    return diagnosis, chief_complaint, ground_truth
+
+
 @orca.service
 class GenerateInitialFeedback(PreviousResponseMixin, FeedbackMixin, DjangoBaseService):
     """Generate the initial patient feedback using Pydantic AI."""
@@ -65,6 +90,12 @@ class GenerateInitialFeedback(PreviousResponseMixin, FeedbackMixin, DjangoBaseSe
 
         history = await sync_to_async(sim.history)()
         messages = [entry for entry in history if entry.get("content")]
+        diagnosis, chief_complaint, ground_truth = _scenario_ground_truth_context(
+            simulation_id,
+            sim,
+        )
+        self.context["scenario_diagnosis"] = diagnosis
+        self.context["scenario_chief_complaint"] = chief_complaint
 
         logger.info(
             "[feedback] simulation=%s messages_loaded=%d has_previous_response=%s",
@@ -94,8 +125,11 @@ class GenerateInitialFeedback(PreviousResponseMixin, FeedbackMixin, DjangoBaseSe
         )
         self.context["user_message"] = (
             "Evaluate the following completed simulation. "
-            "Base your feedback exclusively on this transcript — "
-            "do not invent actions, questions, or omissions not present in the record.\n\n"
+            "Use the Scenario Ground Truth section as the authoritative case answer. "
+            "Use the transcript only to assess what the learner did, asked, missed, or stated. "
+            "Do not infer the correct diagnosis from the transcript when persisted ground truth is available. "
+            "Do not invent actions, questions, or omissions not present in the record.\n\n"
+            f"### Scenario Ground Truth\n{ground_truth}\n\n"
             f"### Simulation Transcript\n{transcript}"
         )
 
@@ -114,3 +148,49 @@ class GenerateFeedbackContinuationReply(FeedbackMixin, DjangoBaseService):
     from apps.simcore.orca.schemas import GenerateFeedbackContinuationResponse as _Schema
 
     response_schema = _Schema
+
+    async def _aprepare_context(self) -> None:
+        if hasattr(super(), "_aprepare_context"):
+            await super()._aprepare_context()
+
+        if self.context.get("user_message"):
+            return
+
+        simulation_id = self.context.get("simulation_id")
+
+        try:
+            from apps.simcore.models import Simulation
+
+            sim = await Simulation.objects.aget(pk=simulation_id)
+        except Exception as exc:
+            logger.warning(
+                "[feedback] simulation %s not found, ground truth unavailable: %s",
+                simulation_id,
+                exc,
+            )
+            return
+
+        diagnosis, chief_complaint, ground_truth = _scenario_ground_truth_context(
+            simulation_id,
+            sim,
+        )
+        self.context["scenario_diagnosis"] = diagnosis
+        self.context["scenario_chief_complaint"] = chief_complaint
+
+        learner_question = (
+            self.context.get("learner_question")
+            or self.context.get("question")
+            or self.context.get("prompt")
+            or ""
+        ).strip()
+        if not learner_question:
+            return
+
+        self.context["user_message"] = (
+            "Answer the learner's follow-up feedback question. "
+            "Use the Scenario Ground Truth section as the authoritative case answer "
+            "when diagnosis or case intent matters. Use the learner question only for "
+            "what the learner is asking now.\n\n"
+            f"### Scenario Ground Truth\n{ground_truth}\n\n"
+            f"### Learner Question\n{learner_question}"
+        )

--- a/SimWorks/apps/simcore/orca/services/feedback.py
+++ b/SimWorks/apps/simcore/orca/services/feedback.py
@@ -19,11 +19,10 @@ def _scenario_ground_truth_context(simulation_id, sim) -> tuple[str, str, str]:
     diagnosis = (getattr(sim, "diagnosis", None) or "").strip()
     chief_complaint = (getattr(sim, "chief_complaint", None) or "").strip()
 
-    ground_truth_lines = []
-    if chief_complaint:
-        ground_truth_lines.append(f"Chief complaint: {chief_complaint}")
-    if diagnosis:
-        ground_truth_lines.append(f"Correct diagnosis: {diagnosis}")
+    ground_truth_lines = [
+        f"Chief complaint: {chief_complaint or 'unavailable'}",
+        f"Correct diagnosis: {diagnosis or 'unavailable'}",
+    ]
 
     if not diagnosis or not chief_complaint:
         logger.warning(
@@ -33,10 +32,13 @@ def _scenario_ground_truth_context(simulation_id, sim) -> tuple[str, str, str]:
             chief_complaint,
         )
 
-    ground_truth = "\n".join(ground_truth_lines) or (
-        "Scenario ground truth is unavailable. State this limitation; do not infer "
-        "the authoritative diagnosis as certain."
-    )
+    if not diagnosis or not chief_complaint:
+        ground_truth_lines.append(
+            "Persisted scenario ground truth is incomplete. State this limitation; "
+            "do not infer any unavailable authoritative case answer as certain."
+        )
+
+    ground_truth = "\n".join(ground_truth_lines)
     return diagnosis, chief_complaint, ground_truth
 
 

--- a/tests/chatlab/test_patient_schemas.py
+++ b/tests/chatlab/test_patient_schemas.py
@@ -39,8 +39,12 @@ class TestPatientInitialSchema:
 
         # Validate required fields present
         assert "messages" in schema_json["properties"]
+        assert "diagnosis" in schema_json["properties"]
+        assert "chief_complaint" in schema_json["properties"]
         assert "metadata" in schema_json["properties"]
         assert "llm_conditions_check" in schema_json["properties"]
+        assert "diagnosis" in schema_json["required"]
+        assert "chief_complaint" in schema_json["required"]
 
         # Validate messages is array with min 1
         messages_prop = schema_json["properties"]["messages"]
@@ -78,6 +82,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             # PatientInitialOutputSchema.metadata is list[MetadataItem] (polymorphic union)
             "metadata": [
                 {"kind": "patient_demographics", "key": "age", "value": "45"},
@@ -92,6 +98,9 @@ class TestPatientInitialSchema:
         # Verify messages structure
         assert len(parsed.messages) == 1
         assert parsed.messages[0].content[0].text == "Hello, I'm the patient."
+        assert parsed.diagnosis == "Acute appendicitis"
+        assert parsed.chief_complaint == "Right lower quadrant abdominal pain"
+        assert parsed.diagnosis not in parsed.messages[0].content[0].text
 
         # Verify metadata as list[MetadataItem] (polymorphic)
         assert len(parsed.metadata) == 2
@@ -117,6 +126,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [],
             "llm_conditions_check": [],
             "extra_field": "should_fail",  # Extra field
@@ -131,6 +142,8 @@ class TestPatientInitialSchema:
         """Verify messages field requires at least one item."""
         invalid_output = {
             "messages": [],  # Empty - should fail
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [],
             "llm_conditions_check": [],
         }
@@ -152,6 +165,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [
                 {
                     "kind": "lab_result",
@@ -191,6 +206,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [
                 {
                     "kind": "rad_result",
@@ -222,6 +239,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [
                 {
                     "kind": "patient_history",
@@ -255,6 +274,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [
                 {"kind": "patient_demographics", "key": "age", "value": "65"},
                 {
@@ -305,6 +326,8 @@ class TestPatientInitialSchema:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [
                 {
                     "kind": "invalid_kind",  # Invalid discriminator
@@ -320,6 +343,46 @@ class TestPatientInitialSchema:
 
         error_str = str(exc_info.value).lower()
         assert "discriminator" in error_str or "kind" in error_str
+
+    def test_schema_requires_diagnosis(self):
+        """Initial schema requires hidden ground-truth diagnosis."""
+        invalid_output = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "My stomach hurts."}],
+                    "item_meta": [],
+                }
+            ],
+            "chief_complaint": "Right lower quadrant abdominal pain",
+            "metadata": [],
+            "llm_conditions_check": [],
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            PatientInitialOutputSchema.model_validate(invalid_output)
+
+        assert "diagnosis" in str(exc_info.value).lower()
+
+    def test_schema_requires_chief_complaint(self):
+        """Initial schema requires hidden ground-truth chief complaint."""
+        invalid_output = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "My stomach hurts."}],
+                    "item_meta": [],
+                }
+            ],
+            "diagnosis": "Acute appendicitis",
+            "metadata": [],
+            "llm_conditions_check": [],
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            PatientInitialOutputSchema.model_validate(invalid_output)
+
+        assert "chief_complaint" in str(exc_info.value).lower()
 
 
 class TestPatientReplySchema:

--- a/tests/chatlab/test_patient_services.py
+++ b/tests/chatlab/test_patient_services.py
@@ -276,6 +276,8 @@ class TestSchemaSerializability:
                     "item_meta": [],
                 }
             ],
+            "diagnosis": "Acute appendicitis",
+            "chief_complaint": "Right lower quadrant abdominal pain",
             "metadata": [],
             "llm_conditions_check": [],
         }

--- a/tests/chatlab/test_persist_schema.py
+++ b/tests/chatlab/test_persist_schema.py
@@ -103,6 +103,8 @@ class TestPatientInitialPersistence:
                         "item_meta": [],
                     }
                 ],
+                "diagnosis": "Acute appendicitis",
+                "chief_complaint": "Right lower quadrant abdominal pain",
                 "metadata": [
                     {"kind": "patient_demographics", "key": "patient_name", "value": "John Smith"},
                     {"kind": "patient_demographics", "key": "age", "value": "45"},
@@ -147,6 +149,8 @@ class TestPatientInitialPersistence:
                         "item_meta": [],
                     }
                 ],
+                "diagnosis": "Acute appendicitis",
+                "chief_complaint": "Right lower quadrant abdominal pain",
                 "metadata": [],
                 "llm_conditions_check": [
                     {"key": "condition_a", "value": "met"},
@@ -174,6 +178,8 @@ class TestPatientInitialPersistence:
                         "item_meta": [],
                     }
                 ],
+                "diagnosis": "Acute appendicitis",
+                "chief_complaint": "Right lower quadrant abdominal pain",
                 "metadata": [
                     {"kind": "patient_demographics", "key": "patient_name", "value": "John Smith"},
                     {"kind": "patient_demographics", "key": "age", "value": "45"},
@@ -214,6 +220,34 @@ class TestPatientInitialPersistence:
         assert "metadata_id" in meta_event.payload
         assert "kind" in meta_event.payload
         assert "key" in meta_event.payload
+
+    async def test_initial_schema_persists_simulation_ground_truth(self, context):
+        """Initial patient output should persist hidden scenario ground truth on Simulation."""
+        schema = PatientInitialOutputSchema.model_validate(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Hi, my lower belly hurts."}],
+                        "item_meta": [],
+                    }
+                ],
+                "diagnosis": "Acute appendicitis",
+                "chief_complaint": "Right lower quadrant abdominal pain",
+                "metadata": [],
+                "llm_conditions_check": [],
+            }
+        )
+
+        result = await persist_schema(schema, context)
+
+        from apps.simcore.models import Simulation
+
+        sim = await Simulation.objects.aget(pk=context.simulation_id)
+        assert sim.diagnosis == "Acute appendicitis"
+        assert sim.chief_complaint == "Right lower quadrant abdominal pain"
+        assert isinstance(result, Message)
+        assert "Acute appendicitis" not in result.content
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/chatlab/test_stitch_services.py
+++ b/tests/chatlab/test_stitch_services.py
@@ -138,3 +138,28 @@ class TestStitchScenarioGroundTruthInstruction:
         assert "### Scenario Ground Truth" in rendered
         assert "Persisted scenario ground truth is unavailable" in rendered
         assert "Do not present an inferred diagnosis as certain" in rendered
+
+    async def test_renders_partial_ground_truth_limitation(self, django_user_model):
+        from apps.accounts.models import UserRole
+        from apps.simcore.models import Simulation
+
+        role = await UserRole.objects.acreate(title="Stitch Partial Ground Truth")
+        user = await sync_to_async(django_user_model.objects.create_user)(
+            email="stitch-partial-ground-truth@example.com",
+            password="testpass123",
+            role=role,
+        )
+        sim = await Simulation.objects.acreate(
+            user=user,
+            diagnosis="",
+            chief_complaint="Right lower quadrant abdominal pain",
+        )
+
+        instruction = StitchScenarioGroundTruthInstruction()
+        instruction.context = {"simulation_id": sim.id}
+        rendered = await instruction.render_instruction()
+
+        assert "- Chief complaint: Right lower quadrant abdominal pain" in rendered
+        assert "- Correct diagnosis: unavailable" in rendered
+        assert "Persisted scenario ground truth is incomplete" in rendered
+        assert "unavailable inferred diagnosis" in rendered

--- a/tests/chatlab/test_stitch_services.py
+++ b/tests/chatlab/test_stitch_services.py
@@ -1,5 +1,6 @@
 """Integration tests for chatlab Stitch services."""
 
+from asgiref.sync import sync_to_async
 import pytest
 
 from apps.chatlab.orca.instructions import (
@@ -7,6 +8,7 @@ from apps.chatlab.orca.instructions import (
     StitchPersonaInstruction,
     StitchReplyDetailInstruction,
     StitchRoleInstruction,
+    StitchScenarioGroundTruthInstruction,
     StitchSchemaContractInstruction,
     StitchToneInstruction,
 )
@@ -28,6 +30,7 @@ class TestGenerateStitchReplyService:
         service = GenerateStitchReply(context={"simulation_id": 1, "conversation_id": 2})
         assert StitchPersonaInstruction in service._instruction_classes
         assert StitchRoleInstruction in service._instruction_classes
+        assert StitchScenarioGroundTruthInstruction in service._instruction_classes
         assert StitchConversationContextInstruction in service._instruction_classes
         assert StitchReplyDetailInstruction in service._instruction_classes
         assert StitchSchemaContractInstruction in service._instruction_classes
@@ -38,6 +41,12 @@ class TestGenerateStitchReplyService:
         names = [cls.__name__ for cls in service._instruction_classes]
 
         assert names.index("StitchPersonaInstruction") < names.index("StitchRoleInstruction")
+        assert names.index("StitchRoleInstruction") < names.index(
+            "StitchScenarioGroundTruthInstruction"
+        )
+        assert names.index("StitchScenarioGroundTruthInstruction") < names.index(
+            "StitchConversationContextInstruction"
+        )
         assert names.index("StitchRoleInstruction") < names.index(
             "StitchConversationContextInstruction"
         )
@@ -79,3 +88,53 @@ class TestGenerateStitchReplyService:
 
         assert service.context["previous_response_id"] == "resp_prev_123"
         assert service.context["previous_provider_response_id"] == "resp_prev_123"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestStitchScenarioGroundTruthInstruction:
+    async def test_renders_persisted_ground_truth(self, django_user_model):
+        from apps.accounts.models import UserRole
+        from apps.simcore.models import Simulation
+
+        role = await UserRole.objects.acreate(title="Stitch Ground Truth")
+        user = await sync_to_async(django_user_model.objects.create_user)(
+            email="stitch-ground-truth@example.com",
+            password="testpass123",
+            role=role,
+        )
+        sim = await Simulation.objects.acreate(
+            user=user,
+            diagnosis="Acute appendicitis",
+            chief_complaint="Right lower quadrant abdominal pain",
+        )
+
+        instruction = StitchScenarioGroundTruthInstruction()
+        instruction.context = {"simulation_id": sim.id}
+        rendered = await instruction.render_instruction()
+
+        assert "### Scenario Ground Truth" in rendered
+        assert "- Chief complaint: Right lower quadrant abdominal pain" in rendered
+        assert "- Correct diagnosis: Acute appendicitis" in rendered
+        assert "authoritative case answer" in rendered
+        assert "Use conversation history only" in rendered
+
+    async def test_renders_limitation_when_ground_truth_missing(self, django_user_model):
+        from apps.accounts.models import UserRole
+        from apps.simcore.models import Simulation
+
+        role = await UserRole.objects.acreate(title="Stitch Missing Ground Truth")
+        user = await sync_to_async(django_user_model.objects.create_user)(
+            email="stitch-missing-ground-truth@example.com",
+            password="testpass123",
+            role=role,
+        )
+        sim = await Simulation.objects.acreate(user=user)
+
+        instruction = StitchScenarioGroundTruthInstruction()
+        instruction.context = {"simulation_id": sim.id}
+        rendered = await instruction.render_instruction()
+
+        assert "### Scenario Ground Truth" in rendered
+        assert "Persisted scenario ground truth is unavailable" in rendered
+        assert "Do not present an inferred diagnosis as certain" in rendered

--- a/tests/simulation/test_feedback_services.py
+++ b/tests/simulation/test_feedback_services.py
@@ -12,7 +12,10 @@ import types
 
 import pytest
 
-from apps.simcore.orca.services.feedback import GenerateInitialFeedback
+from apps.simcore.orca.services.feedback import (
+    GenerateFeedbackContinuationReply,
+    GenerateInitialFeedback,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
@@ -27,10 +30,16 @@ def _make_history(*pairs):
     ]
 
 
-def _make_mock_sim(history_data):
+def _make_mock_sim(
+    history_data,
+    diagnosis="Acute coronary syndrome",
+    chief_complaint="Chest pain",
+):
     """Return a lightweight mock simulation object."""
     sim = types.SimpleNamespace()
     sim.history = lambda _format=None: history_data
+    sim.diagnosis = diagnosis
+    sim.chief_complaint = chief_complaint
     return sim
 
 
@@ -107,6 +116,34 @@ class TestPrepareTranscriptContext:
         assert "simulation" in user_msg or "transcript" in user_msg
 
     @pytest.mark.asyncio
+    async def test_user_message_separates_ground_truth_from_transcript(self, monkeypatch):
+        history = _make_history(
+            ("A", "Patient", "My stomach hurts."),
+            ("U", "Learner", "Where is the pain?"),
+        )
+        sim = _make_mock_sim(
+            history,
+            diagnosis="Acute appendicitis",
+            chief_complaint="Right lower quadrant abdominal pain",
+        )
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 42})
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "")
+        assert "### Scenario Ground Truth" in user_msg
+        assert "Chief complaint: Right lower quadrant abdominal pain" in user_msg
+        assert "Correct diagnosis: Acute appendicitis" in user_msg
+        assert "### Simulation Transcript" in user_msg
+        assert "Where is the pain?" in user_msg
+        assert service.context["scenario_diagnosis"] == "Acute appendicitis"
+        assert (
+            service.context["scenario_chief_complaint"]
+            == "Right lower quadrant abdominal pain"
+        )
+
+    @pytest.mark.asyncio
     async def test_messages_are_chronologically_included(self, monkeypatch):
         history = _make_history(
             ("U", "Learner", "First message"),
@@ -165,6 +202,23 @@ class TestEmptyTranscriptFallback:
         user_msg = service.context.get("user_message", "").lower()
         assert "unavailable" in user_msg or "no messages" in user_msg or "incomplete" in user_msg
 
+    @pytest.mark.asyncio
+    async def test_missing_ground_truth_sets_limitation(self, monkeypatch):
+        history = _make_history(
+            ("A", "Patient", "My stomach hurts."),
+            ("U", "Learner", "Any vomiting?"),
+        )
+        sim = _make_mock_sim(history, diagnosis="", chief_complaint="")
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 99})
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "")
+        assert "Scenario ground truth is unavailable" in user_msg
+        assert "do not infer the authoritative diagnosis as certain" in user_msg
+        assert "Any vomiting?" in user_msg
+
 
 # ---------------------------------------------------------------------------
 # Test C — Grounding regression: actual transcript content reaches user_message
@@ -201,6 +255,46 @@ class TestGroundingRegression:
         assert service.context["user_message"] == caller_msg
 
 
+class TestContinuationGroundTruthContext:
+    @pytest.mark.asyncio
+    async def test_continuation_user_message_includes_ground_truth_and_question(
+        self,
+        monkeypatch,
+    ):
+        sim = _make_mock_sim(
+            _make_history(("A", "Patient", "My stomach hurts.")),
+            diagnosis="Acute appendicitis",
+            chief_complaint="Right lower quadrant abdominal pain",
+        )
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateFeedbackContinuationReply(
+            context={
+                "simulation_id": 7,
+                "question": "Was my diagnosis correct?",
+            }
+        )
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "")
+        assert "### Scenario Ground Truth" in user_msg
+        assert "Correct diagnosis: Acute appendicitis" in user_msg
+        assert "### Learner Question" in user_msg
+        assert "Was my diagnosis correct?" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_continuation_preserves_caller_user_message(self, monkeypatch):
+        sim = _make_mock_sim(_make_history(("A", "Patient", "Hello.")))
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateFeedbackContinuationReply(
+            context={"simulation_id": 7, "user_message": "Already prepared."}
+        )
+        await service._aprepare_context()
+
+        assert service.context["user_message"] == "Already prepared."
+
+
 # ---------------------------------------------------------------------------
 # Test D — Instruction regression: grounding language present in YAML
 # ---------------------------------------------------------------------------
@@ -219,6 +313,17 @@ class TestInstructionGroundingLanguage:
         assert "simulation transcript" in text.lower(), (
             "FeedbackInitialInstruction must reference 'simulation transcript'"
         )
+
+    def test_instruction_uses_scenario_ground_truth_for_diagnosis(self):
+        text = self._load_instruction_text()
+        assert "scenario ground truth" in text.lower()
+        assert "authoritative source for the correct" in text.lower()
+
+    def test_instruction_uses_transcript_for_learner_actions(self):
+        text = self._load_instruction_text()
+        assert "learner actions" in text.lower()
+        assert "questions" in text.lower()
+        assert "omissions" in text.lower()
 
     def test_instruction_prohibits_invention(self):
         text = self._load_instruction_text()

--- a/tests/simulation/test_feedback_services.py
+++ b/tests/simulation/test_feedback_services.py
@@ -138,10 +138,7 @@ class TestPrepareTranscriptContext:
         assert "### Simulation Transcript" in user_msg
         assert "Where is the pain?" in user_msg
         assert service.context["scenario_diagnosis"] == "Acute appendicitis"
-        assert (
-            service.context["scenario_chief_complaint"]
-            == "Right lower quadrant abdominal pain"
-        )
+        assert service.context["scenario_chief_complaint"] == "Right lower quadrant abdominal pain"
 
     @pytest.mark.asyncio
     async def test_messages_are_chronologically_included(self, monkeypatch):

--- a/tests/simulation/test_feedback_services.py
+++ b/tests/simulation/test_feedback_services.py
@@ -212,9 +212,33 @@ class TestEmptyTranscriptFallback:
         await service._aprepare_context()
 
         user_msg = service.context.get("user_message", "")
-        assert "Scenario ground truth is unavailable" in user_msg
-        assert "do not infer the authoritative diagnosis as certain" in user_msg
+        assert "Chief complaint: unavailable" in user_msg
+        assert "Correct diagnosis: unavailable" in user_msg
+        assert "Persisted scenario ground truth is incomplete" in user_msg
+        assert "do not infer any unavailable authoritative case answer as certain" in user_msg
         assert "Any vomiting?" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_partial_ground_truth_marks_missing_diagnosis_unavailable(self, monkeypatch):
+        history = _make_history(
+            ("A", "Patient", "My stomach hurts."),
+            ("U", "Learner", "Any vomiting?"),
+        )
+        sim = _make_mock_sim(
+            history,
+            diagnosis="",
+            chief_complaint="Right lower quadrant abdominal pain",
+        )
+        _patch_simulation(monkeypatch, sim)
+
+        service = GenerateInitialFeedback(context={"simulation_id": 99})
+        await service._aprepare_context()
+
+        user_msg = service.context.get("user_message", "")
+        assert "Chief complaint: Right lower quadrant abdominal pain" in user_msg
+        assert "Correct diagnosis: unavailable" in user_msg
+        assert "Persisted scenario ground truth is incomplete" in user_msg
+        assert "do not infer any unavailable authoritative case answer as certain" in user_msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added hidden `diagnosis` and `chief_complaint` fields to the initial ChatLab patient schema and persisted them onto `Simulation` during `post_persist()`.
- Updated patient, feedback, and Stitch instructions so scenario ground truth is handled separately from visible transcript content.
- Grounded initial feedback and follow-up feedback context in persisted scenario data, with explicit fallback behavior when ground truth is missing.
- Added coverage for schema validation, persistence, feedback grounding, and Stitch instruction rendering.

## Testing
- `uv run pytest tests/chatlab/test_patient_schemas.py tests/chatlab/test_persist_schema.py tests/simulation/test_feedback_services.py tests/chatlab/test_stitch_services.py -q`
- `uv run python SimWorks/manage.py check`
- `git diff --check`
- `uv run ruff check SimWorks/apps/chatlab/orca/schemas/patient.py SimWorks/apps/simcore/orca/services/feedback.py SimWorks/apps/chatlab/orca/instructions/stitch.py SimWorks/apps/chatlab/orca/services/stitch.py SimWorks/apps/chatlab/orca/instructions/__init__.py tests/chatlab/test_patient_schemas.py tests/chatlab/test_persist_schema.py tests/chatlab/test_stitch_services.py tests/simulation/test_feedback_services.py`